### PR TITLE
[codex] isolate read session runtime and document session topology

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,7 +19,16 @@ TG_SECRET_CMD_API_ID=
 TG_SECRET_CMD_API_HASH=
 
 # Session name (for direct CLI debug only; MCP should use TG_SESSION_PATH)
-SESSION_NAME=read_only_session
+SESSION_NAME=read_only_ro
+
+# Recommended session split for MCP:
+# - read  -> data/sessions/<account>_ro.session
+# - write -> data/sessions/<account>.session
+# Optional cross-server metadata for same-session preflight/warnings.
+TG_READ_SESSION_PATH=
+TG_ACTIONS_SESSION_PATH=
+TG_SESSION_PATH_CONFLICT_MODE=warn   # off|warn|fail
+TG_SESSION_CONFLICT_REGISTRY_FILE=
 
 # MCP session behavior (optional)
 TG_ALLOW_SESSION_SWITCH=0        # 1 to allow tg_use_session tool

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Run tests
         env:
           PYTHONPATH: tganalytics:.
-          TG_API_ID: "0"
-          TG_API_HASH: "test"
+          TG_API_ID: "1"
+          TG_API_HASH: "testhash"
         run: |
           python -m pytest tests/ -q

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,12 +1,20 @@
 {
   "mcpServers": {
     "tgmcp-read": {
-      "command": "venv/bin/python3",
-      "args": ["tganalytics/mcp_server_read.py"],
+      "command": "/bin/bash",
+      "args": [
+        "-lc",
+        "cd /Users/dmitrymatskevich/tg-mcp && exec /Users/dmitrymatskevich/tg-mcp/venv/bin/python3 /Users/dmitrymatskevich/tg-mcp/tganalytics/mcp_server_read.py"
+      ],
       "env": {
-        "PYTHONPATH": "tganalytics:.",
-        "TG_SESSIONS_DIR": "data/sessions",
-        "TG_SESSION_PATH": "data/sessions/dmatskevich_ro.session",
+        "PYTHONPATH": "/Users/dmitrymatskevich/tg-mcp/tganalytics:/Users/dmitrymatskevich/tg-mcp",
+        "TG_SESSIONS_DIR": "/Users/dmitrymatskevich/tg-mcp/data/sessions",
+        "TG_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich_ro.session",
+        "TG_READ_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich_ro.session",
+        "TG_ACTIONS_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich.session",
+        "TG_SESSION_PATH_CONFLICT_MODE": "fail",
+        "TG_SESSION_CONFLICT_REGISTRY_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/session_registry.json",
+        "TG_EXPECTED_USERNAME": "dmatskevich",
         "TG_ALLOW_SESSION_SWITCH": "0",
         "TG_BLOCK_DIRECT_TELETHON_WRITE": "1",
         "TG_ALLOW_DIRECT_TELETHON_WRITE": "0",
@@ -14,6 +22,7 @@
         "TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS": "actions_mcp",
         "TG_WRITE_CONTEXT": "read_mcp",
         "TG_ACTION_PROCESS": "0",
+        "TG_RECEIVE_UPDATES": "0",
         "TG_SESSION_LOCK_MODE": "shared",
         "TG_GLOBAL_RPS_MODE": "shared",
         "TG_FLOOD_CIRCUIT_THRESHOLD_SEC": "300",
@@ -21,16 +30,24 @@
       }
     },
     "tgmcp-actions": {
-      "command": "venv/bin/python3",
-      "args": ["tganalytics/mcp_server_actions.py"],
+      "command": "/bin/bash",
+      "args": [
+        "-lc",
+        "cd /Users/dmitrymatskevich/tg-mcp && exec /Users/dmitrymatskevich/tg-mcp/venv/bin/python3 /Users/dmitrymatskevich/tg-mcp/tganalytics/mcp_server_actions.py"
+      ],
       "env": {
-        "PYTHONPATH": "tganalytics:.",
-        "TG_SESSIONS_DIR": "data/sessions",
-        "TG_SESSION_PATH": "data/sessions/dmatskevich.session",
+        "PYTHONPATH": "/Users/dmitrymatskevich/tg-mcp/tganalytics:/Users/dmitrymatskevich/tg-mcp",
+        "TG_SESSIONS_DIR": "/Users/dmitrymatskevich/tg-mcp/data/sessions",
+        "TG_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich.session",
+        "TG_READ_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich_ro.session",
+        "TG_ACTIONS_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich.session",
+        "TG_SESSION_PATH_CONFLICT_MODE": "fail",
+        "TG_SESSION_CONFLICT_REGISTRY_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/session_registry.json",
+        "TG_EXPECTED_USERNAME": "dmatskevich",
         "TG_ALLOW_SESSION_SWITCH": "0",
         "TG_ACTIONS_ENABLED": "1",
         "TG_ACTIONS_REQUIRE_ALLOWLIST": "1",
-        "TG_ACTIONS_ALLOWED_GROUPS": "",
+        "TG_ACTIONS_ALLOWED_GROUPS": "dmatskevich,16643982,-5023804528",
         "TG_ACTIONS_MAX_MESSAGE_LEN": "2000",
         "TG_ACTIONS_MAX_FILE_MB": "20",
         "TG_ACTIONS_REQUIRE_CONFIRMATION_TEXT": "1",
@@ -39,10 +56,11 @@
         "TG_ACTIONS_REQUIRE_APPROVAL_CODE": "1",
         "TG_ACTIONS_APPROVAL_TTL_SEC": "1800",
         "TG_ACTIONS_APPROVAL_MIN_AGE_SEC": "30",
-        "TG_ACTIONS_APPROVAL_FILE": "data/anti_spam/action_approvals.json",
+        "TG_ACTIONS_APPROVAL_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/action_approvals.json",
         "TG_ACTIONS_IDEMPOTENCY_ENABLED": "1",
         "TG_ACTIONS_IDEMPOTENCY_WINDOW_SEC": "86400",
-        "TG_ACTIONS_BATCH_FILE": "data/anti_spam/action_batches.json",
+        "TG_ACTIONS_IDEMPOTENCY_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/action_idempotency.json",
+        "TG_ACTIONS_BATCH_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/action_batches.json",
         "TG_ACTIONS_BATCH_TTL_HOURS": "168",
         "TG_ACTIONS_BATCH_APPROVAL_LEASE_SEC": "86400",
         "TG_ACTIONS_BATCH_RUN_LEASE_SEC": "1800",
@@ -52,12 +70,16 @@
         "TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS": "actions_mcp",
         "TG_WRITE_CONTEXT": "actions_mcp",
         "TG_ACTION_PROCESS": "1",
+        "TG_RECEIVE_UPDATES": "0",
         "TG_SESSION_LOCK_MODE": "shared",
         "TG_GLOBAL_RPS_MODE": "shared",
         "TG_FLOOD_CIRCUIT_THRESHOLD_SEC": "300",
         "TG_FLOOD_CIRCUIT_COOLDOWN_SEC": "900",
         "MAX_GROUP_MSGS_PER_DAY": "30"
       }
+    },
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,20 +1,16 @@
 {
   "mcpServers": {
     "tgmcp-read": {
-      "command": "/bin/bash",
-      "args": [
-        "-lc",
-        "cd /Users/dmitrymatskevich/tg-mcp && exec /Users/dmitrymatskevich/tg-mcp/venv/bin/python3 /Users/dmitrymatskevich/tg-mcp/tganalytics/mcp_server_read.py"
-      ],
+      "command": "venv/bin/python3",
+      "args": ["tganalytics/mcp_server_read.py"],
       "env": {
-        "PYTHONPATH": "/Users/dmitrymatskevich/tg-mcp/tganalytics:/Users/dmitrymatskevich/tg-mcp",
-        "TG_SESSIONS_DIR": "/Users/dmitrymatskevich/tg-mcp/data/sessions",
-        "TG_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich_ro.session",
-        "TG_READ_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich_ro.session",
-        "TG_ACTIONS_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich.session",
+        "PYTHONPATH": "tganalytics:.",
+        "TG_SESSIONS_DIR": "data/sessions",
+        "TG_SESSION_PATH": "data/sessions/read_only_ro.session",
+        "TG_READ_SESSION_PATH": "data/sessions/read_only_ro.session",
+        "TG_ACTIONS_SESSION_PATH": "data/sessions/actions_session.session",
         "TG_SESSION_PATH_CONFLICT_MODE": "fail",
-        "TG_SESSION_CONFLICT_REGISTRY_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/session_registry.json",
-        "TG_EXPECTED_USERNAME": "dmatskevich",
+        "TG_SESSION_CONFLICT_REGISTRY_FILE": "data/anti_spam/session_registry.json",
         "TG_ALLOW_SESSION_SWITCH": "0",
         "TG_BLOCK_DIRECT_TELETHON_WRITE": "1",
         "TG_ALLOW_DIRECT_TELETHON_WRITE": "0",
@@ -22,6 +18,7 @@
         "TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS": "actions_mcp",
         "TG_WRITE_CONTEXT": "read_mcp",
         "TG_ACTION_PROCESS": "0",
+        "TG_SESSION_RUNTIME_MODE": "copy",
         "TG_RECEIVE_UPDATES": "0",
         "TG_SESSION_LOCK_MODE": "shared",
         "TG_GLOBAL_RPS_MODE": "shared",
@@ -30,24 +27,20 @@
       }
     },
     "tgmcp-actions": {
-      "command": "/bin/bash",
-      "args": [
-        "-lc",
-        "cd /Users/dmitrymatskevich/tg-mcp && exec /Users/dmitrymatskevich/tg-mcp/venv/bin/python3 /Users/dmitrymatskevich/tg-mcp/tganalytics/mcp_server_actions.py"
-      ],
+      "command": "venv/bin/python3",
+      "args": ["tganalytics/mcp_server_actions.py"],
       "env": {
-        "PYTHONPATH": "/Users/dmitrymatskevich/tg-mcp/tganalytics:/Users/dmitrymatskevich/tg-mcp",
-        "TG_SESSIONS_DIR": "/Users/dmitrymatskevich/tg-mcp/data/sessions",
-        "TG_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich.session",
-        "TG_READ_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich_ro.session",
-        "TG_ACTIONS_SESSION_PATH": "/Users/dmitrymatskevich/tg-mcp/data/sessions/dmatskevich.session",
+        "PYTHONPATH": "tganalytics:.",
+        "TG_SESSIONS_DIR": "data/sessions",
+        "TG_SESSION_PATH": "data/sessions/actions_session.session",
+        "TG_READ_SESSION_PATH": "data/sessions/read_only_ro.session",
+        "TG_ACTIONS_SESSION_PATH": "data/sessions/actions_session.session",
         "TG_SESSION_PATH_CONFLICT_MODE": "fail",
-        "TG_SESSION_CONFLICT_REGISTRY_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/session_registry.json",
-        "TG_EXPECTED_USERNAME": "dmatskevich",
+        "TG_SESSION_CONFLICT_REGISTRY_FILE": "data/anti_spam/session_registry.json",
         "TG_ALLOW_SESSION_SWITCH": "0",
         "TG_ACTIONS_ENABLED": "1",
         "TG_ACTIONS_REQUIRE_ALLOWLIST": "1",
-        "TG_ACTIONS_ALLOWED_GROUPS": "dmatskevich,16643982,-5023804528",
+        "TG_ACTIONS_ALLOWED_GROUPS": "",
         "TG_ACTIONS_MAX_MESSAGE_LEN": "2000",
         "TG_ACTIONS_MAX_FILE_MB": "20",
         "TG_ACTIONS_REQUIRE_CONFIRMATION_TEXT": "1",
@@ -56,11 +49,11 @@
         "TG_ACTIONS_REQUIRE_APPROVAL_CODE": "1",
         "TG_ACTIONS_APPROVAL_TTL_SEC": "1800",
         "TG_ACTIONS_APPROVAL_MIN_AGE_SEC": "30",
-        "TG_ACTIONS_APPROVAL_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/action_approvals.json",
+        "TG_ACTIONS_APPROVAL_FILE": "data/anti_spam/action_approvals.json",
         "TG_ACTIONS_IDEMPOTENCY_ENABLED": "1",
         "TG_ACTIONS_IDEMPOTENCY_WINDOW_SEC": "86400",
-        "TG_ACTIONS_IDEMPOTENCY_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/action_idempotency.json",
-        "TG_ACTIONS_BATCH_FILE": "/Users/dmitrymatskevich/tg-mcp/data/anti_spam/action_batches.json",
+        "TG_ACTIONS_IDEMPOTENCY_FILE": "data/anti_spam/action_idempotency.json",
+        "TG_ACTIONS_BATCH_FILE": "data/anti_spam/action_batches.json",
         "TG_ACTIONS_BATCH_TTL_HOURS": "168",
         "TG_ACTIONS_BATCH_APPROVAL_LEASE_SEC": "86400",
         "TG_ACTIONS_BATCH_RUN_LEASE_SEC": "1800",
@@ -77,9 +70,6 @@
         "TG_FLOOD_CIRCUIT_COOLDOWN_SEC": "900",
         "MAX_GROUP_MSGS_PER_DAY": "30"
       }
-    },
-    "context7": {
-      "url": "https://mcp.context7.com/mcp"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -116,20 +116,27 @@ bash scripts/check_tg_mcp.sh /absolute/path/to/tg-mcp
 # read-only config (safe default)
 python3 scripts/render_mcp_config.py \
   --repo /absolute/path/to/tg-mcp \
-  --profile read
+  --profile read \
+  --read-session-name my_account_ro
 
 # full config (read + actions)
 python3 scripts/render_mcp_config.py \
   --repo /absolute/path/to/tg-mcp \
   --profile full \
-  --read-session-name my_read \
-  --actions-session-name my_actions
+  --read-session-name my_account_ro \
+  --actions-session-name my_account
+
+# preflight: fail fast on same-session misconfig
+python3 scripts/check_session_paths.py \
+  --read-session-path /absolute/path/to/tg-mcp/data/sessions/my_account_ro.session \
+  --actions-session-path /absolute/path/to/tg-mcp/data/sessions/my_account.session
 ```
 
 ## Global MCP Setup (All Projects in Codex)
 
 For one global setup across all working directories, add servers via `codex mcp add`.
-Use one shared `TG_SESSION_PATH` for your read session.
+Recommended default: separate session files for read and actions.
+Routine concurrent read+actions traffic on one Telethon sqlite session can trigger `database is locked`.
 
 ```bash
 REPO="/absolute/path/to/tg-mcp"
@@ -137,7 +144,11 @@ REPO="/absolute/path/to/tg-mcp"
 codex mcp add tgmcp-read \
   --env PYTHONPATH="$REPO/tganalytics:$REPO" \
   --env TG_SESSIONS_DIR="$REPO/data/sessions" \
-  --env TG_SESSION_PATH="$REPO/data/sessions/my_read.session" \
+  --env TG_SESSION_PATH="$REPO/data/sessions/my_account_ro.session" \
+  --env TG_READ_SESSION_PATH="$REPO/data/sessions/my_account_ro.session" \
+  --env TG_ACTIONS_SESSION_PATH="$REPO/data/sessions/my_account.session" \
+  --env TG_SESSION_PATH_CONFLICT_MODE=warn \
+  --env TG_SESSION_CONFLICT_REGISTRY_FILE="$REPO/data/anti_spam/session_registry.json" \
   --env TG_EXPECTED_USERNAME="my_main_account" \
   --env TG_ALLOW_SESSION_SWITCH=0 \
   --env TG_BLOCK_DIRECT_TELETHON_WRITE=1 \
@@ -146,6 +157,7 @@ codex mcp add tgmcp-read \
   --env TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS=actions_mcp \
   --env TG_WRITE_CONTEXT=read_mcp \
   --env TG_ACTION_PROCESS=0 \
+  --env TG_SESSION_RUNTIME_MODE=copy \
   --env TG_RECEIVE_UPDATES=0 \
   --env TG_SESSION_LOCK_MODE=shared \
   --env TG_GLOBAL_RPS_MODE=shared \
@@ -160,7 +172,11 @@ REPO="/absolute/path/to/tg-mcp"
 codex mcp add tgmcp-actions \
   --env PYTHONPATH="$REPO/tganalytics:$REPO" \
   --env TG_SESSIONS_DIR="$REPO/data/sessions" \
-  --env TG_SESSION_PATH="$REPO/data/sessions/my_actions.session" \
+  --env TG_SESSION_PATH="$REPO/data/sessions/my_account.session" \
+  --env TG_READ_SESSION_PATH="$REPO/data/sessions/my_account_ro.session" \
+  --env TG_ACTIONS_SESSION_PATH="$REPO/data/sessions/my_account.session" \
+  --env TG_SESSION_PATH_CONFLICT_MODE=warn \
+  --env TG_SESSION_CONFLICT_REGISTRY_FILE="$REPO/data/anti_spam/session_registry.json" \
   --env TG_EXPECTED_USERNAME="my_main_account" \
   --env TG_ALLOW_SESSION_SWITCH=0 \
   --env TG_ACTIONS_ENABLED=1 \
@@ -193,7 +209,11 @@ Add to your project's `.mcp.json`:
       "env": {
         "PYTHONPATH": "path/to/tg-mcp/tganalytics:path/to/tg-mcp",
         "TG_SESSIONS_DIR": "path/to/tg-mcp/data/sessions",
-        "TG_SESSION_PATH": "path/to/tg-mcp/data/sessions/my_read.session",
+        "TG_SESSION_PATH": "path/to/tg-mcp/data/sessions/my_account_ro.session",
+        "TG_READ_SESSION_PATH": "path/to/tg-mcp/data/sessions/my_account_ro.session",
+        "TG_ACTIONS_SESSION_PATH": "path/to/tg-mcp/data/sessions/my_account.session",
+        "TG_SESSION_PATH_CONFLICT_MODE": "warn",
+        "TG_SESSION_CONFLICT_REGISTRY_FILE": "path/to/tg-mcp/data/anti_spam/session_registry.json",
         "TG_EXPECTED_USERNAME": "my_main_account",
         "TG_ALLOW_SESSION_SWITCH": "0",
         "TG_BLOCK_DIRECT_TELETHON_WRITE": "1",
@@ -202,6 +222,7 @@ Add to your project's `.mcp.json`:
         "TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS": "actions_mcp",
         "TG_WRITE_CONTEXT": "read_mcp",
         "TG_ACTION_PROCESS": "0",
+        "TG_SESSION_RUNTIME_MODE": "copy",
         "TG_RECEIVE_UPDATES": "0",
         "TG_SESSION_LOCK_MODE": "shared",
         "TG_GLOBAL_RPS_MODE": "shared"
@@ -213,7 +234,11 @@ Add to your project's `.mcp.json`:
       "env": {
         "PYTHONPATH": "path/to/tg-mcp/tganalytics:path/to/tg-mcp",
         "TG_SESSIONS_DIR": "path/to/tg-mcp/data/sessions",
-        "TG_SESSION_PATH": "path/to/tg-mcp/data/sessions/my_actions.session",
+        "TG_SESSION_PATH": "path/to/tg-mcp/data/sessions/my_account.session",
+        "TG_READ_SESSION_PATH": "path/to/tg-mcp/data/sessions/my_account_ro.session",
+        "TG_ACTIONS_SESSION_PATH": "path/to/tg-mcp/data/sessions/my_account.session",
+        "TG_SESSION_PATH_CONFLICT_MODE": "warn",
+        "TG_SESSION_CONFLICT_REGISTRY_FILE": "path/to/tg-mcp/data/anti_spam/session_registry.json",
         "TG_EXPECTED_USERNAME": "my_main_account",
         "TG_ALLOW_SESSION_SWITCH": "0",
         "TG_ACTIONS_ENABLED": "1",
@@ -300,8 +325,16 @@ Add to your project's `.mcp.json`:
 ### Session Concurrency
 
 - Default mode is `TG_SESSION_LOCK_MODE=shared`: multiple MCP servers/projects can use one `.session`.
+- `tgmcp-read` now defaults to `TG_SESSION_RUNTIME_MODE=copy`: each MCP process reads from its own runtime shadow of the configured session file, which avoids sqlite lock collisions across multiple Codex clients.
 - Optional strict mode: `TG_SESSION_LOCK_MODE=exclusive` blocks concurrent use of the same session.
-- For production safety, prefer separate sessions for Read and Actions even if shared mode is allowed.
+- Shared session is still allowed, but NOT recommended for routine concurrent `tgmcp-read` + `tgmcp-actions`.
+- Recommended default:
+- `tgmcp-read` -> dedicated `*_ro.session`
+- `tgmcp-actions` -> dedicated write session (for example `account.session`)
+- If both profiles point to one sqlite session file, Telethon can fail with `database is locked`.
+- Set `TG_READ_SESSION_PATH` + `TG_ACTIONS_SESSION_PATH` in both server envs so runtime can warn/fail on same-session misconfig.
+- `TG_SESSION_PATH_CONFLICT_MODE=warn` prints startup/runtime warning; set `fail` to block server start on same-session conflict.
+- Run `python3 scripts/check_session_paths.py --config /path/to/.mcp.json` before enabling both servers.
 - `TG_EXPECTED_USERNAME` enables fail-fast on session/account mismatch (`@expected` vs actual account in session).
 - `TG_RECEIVE_UPDATES=0` (default) disables Telethon updates loop to reduce sqlite session lock contention.
 - `TG_GLOBAL_RPS_MODE=shared` applies one shared RPS budget across all processes using the same `data/anti_spam`.

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -68,6 +68,8 @@ Use this when user wants one approval and then autonomous processing of many gro
 ## 6. Auth Diagnostics
 
 - Use `tg_auth_status` to verify `authorized=true/false` and current session identity.
+- `tg_auth_status` now also reports `session_path_status`; treat same-session read/actions warning as real risk, not noise.
+- `tgmcp-read` defaults to `TG_SESSION_RUNTIME_MODE=copy`, so duplicate read MCP processes use per-process runtime session copies instead of contending on one sqlite file.
 - Use `scripts/create_session_qr.py` if app/SMS code flow is unreliable.
 - Login code usually comes via Telegram app (`SentCodeTypeApp`), not SMS.
 - If `.env` is restricted, use `TG_SECRET_PROVIDER=keychain|command` for `TG_API_ID/TG_API_HASH`.
@@ -77,8 +79,12 @@ Use this when user wants one approval and then autonomous processing of many gro
 - Shared session is supported with `TG_SESSION_LOCK_MODE=shared`.
 - Shared RPS/circuit state is supported with common `data/anti_spam` and `TG_GLOBAL_RPS_MODE=shared`.
 - Recommended for production:
-- separate read/actions sessions
+- separate read/actions sessions by default
+- read -> `*_ro.session`
+- actions -> main write session
 - dedicated OS user for MCP process
+- configure `TG_READ_SESSION_PATH` and `TG_ACTIONS_SESSION_PATH` in both servers so runtime can detect same-session misconfig
+- run `python3 scripts/check_session_paths.py --config /path/to/.mcp.json` before enabling both servers
 
 ## 8. Never Do This
 

--- a/scripts/check_session_paths.py
+++ b/scripts/check_session_paths.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Preflight check for read/actions Telegram session separation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _resolve_session_path(raw_path: str) -> str:
+    raw = str(raw_path or "").strip()
+    if not raw:
+        return ""
+    return str(Path(raw).expanduser().resolve())
+
+
+def _extract_session_paths_from_config(
+    config_path: Path,
+    read_server_name: str,
+    actions_server_name: str,
+) -> tuple[str, str]:
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    servers = payload.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise ValueError("config does not contain object mcpServers")
+
+    read_server = servers.get(read_server_name)
+    actions_server = servers.get(actions_server_name)
+    if not isinstance(read_server, dict):
+        raise ValueError(f"missing server '{read_server_name}' in mcpServers")
+    if not isinstance(actions_server, dict):
+        raise ValueError(f"missing server '{actions_server_name}' in mcpServers")
+
+    read_env = read_server.get("env", {})
+    actions_env = actions_server.get("env", {})
+    if not isinstance(read_env, dict) or not isinstance(actions_env, dict):
+        raise ValueError("server env must be an object")
+
+    return (
+        _resolve_session_path(str(read_env.get("TG_SESSION_PATH", ""))),
+        _resolve_session_path(str(actions_env.get("TG_SESSION_PATH", ""))),
+    )
+
+
+def _print_ok(read_path: str, actions_path: str) -> int:
+    print("ok: read/actions use separate session files")
+    print(f"read: {read_path}")
+    print(f"actions: {actions_path}")
+    return 0
+
+
+def _print_conflict(read_path: str, actions_path: str) -> int:
+    print("error: read/actions share one Telegram session file", file=sys.stderr)
+    print(f"session: {read_path}", file=sys.stderr)
+    print(
+        "cause: concurrent Telethon read+write MCP processes can hit sqlite 'database is locked'",
+        file=sys.stderr,
+    )
+    print(
+        "fix: use separate sessions by default: read -> *_ro.session, actions -> write session",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", help="Path to .mcp.json or rendered config JSON")
+    parser.add_argument("--read-session-path", help="Explicit TG_SESSION_PATH for tgmcp-read")
+    parser.add_argument("--actions-session-path", help="Explicit TG_SESSION_PATH for tgmcp-actions")
+    parser.add_argument("--read-server-name", default="tgmcp-read")
+    parser.add_argument("--actions-server-name", default="tgmcp-actions")
+    args = parser.parse_args()
+
+    if args.config:
+        config_path = Path(args.config).expanduser().resolve()
+        read_path, actions_path = _extract_session_paths_from_config(
+            config_path,
+            args.read_server_name,
+            args.actions_server_name,
+        )
+    else:
+        read_path = _resolve_session_path(args.read_session_path or "")
+        actions_path = _resolve_session_path(args.actions_session_path or "")
+
+    if not read_path:
+        print("error: read session path is empty", file=sys.stderr)
+        return 1
+    if not actions_path:
+        print("error: actions session path is empty", file=sys.stderr)
+        return 1
+    if read_path == actions_path:
+        return _print_conflict(read_path, actions_path)
+    return _print_ok(read_path, actions_path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_tg_mcp.sh
+++ b/scripts/check_tg_mcp.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 REPO_PATH="${1:-}"
+MCP_CONFIG_PATH="${2:-}"
 if [[ -z "${REPO_PATH}" ]]; then
-  echo "Usage: $0 /absolute/path/to/tg-mcp"
+  echo "Usage: $0 /absolute/path/to/tg-mcp [/absolute/path/to/.mcp.json]"
   exit 1
 fi
 
@@ -45,8 +46,17 @@ if [[ ${missing} -eq 1 ]]; then
   exit 2
 fi
 
+if [[ -n "${MCP_CONFIG_PATH}" ]]; then
+  if [[ ! -f "${MCP_CONFIG_PATH}" ]]; then
+    echo "Error: MCP config does not exist: ${MCP_CONFIG_PATH}"
+    exit 2
+  fi
+  echo "Session preflight:"
+  "${PYTHON_BIN}" "${REPO_PATH}/scripts/check_session_paths.py" --config "${MCP_CONFIG_PATH}"
+fi
+
 if compgen -G "${REPO_PATH}/data/sessions/*.session" > /dev/null; then
-  if ! auth_report="$(cd "${REPO_PATH}" && PYTHONPATH=tganalytics:. TG_AUTH_BOOTSTRAP=1 "${PYTHON_BIN}" - <<'PY' 2>/dev/null
+  if ! auth_report="$(cd "${REPO_PATH}" && PYTHONPATH=tganalytics:. TG_AUTH_BOOTSTRAP=1 TG_SESSION_RUNTIME_MODE=copy "${PYTHON_BIN}" - <<'PY' 2>/dev/null
 import asyncio
 from pathlib import Path
 

--- a/scripts/render_mcp_config.py
+++ b/scripts/render_mcp_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 
 
@@ -12,12 +13,21 @@ def _build_read_server(
     repo: Path,
     server_name: str,
     session_name: str,
+    actions_session_name: str,
     expected_username: str = "",
 ) -> dict:
+    read_session_path = str((repo / f"data/sessions/{session_name}.session").resolve())
+    actions_session_path = str((repo / f"data/sessions/{actions_session_name}.session").resolve())
     env = {
         "PYTHONPATH": f"{(repo / 'tganalytics').resolve()}:{repo.resolve()}",
         "TG_SESSIONS_DIR": str((repo / "data/sessions").resolve()),
-        "TG_SESSION_PATH": str((repo / f"data/sessions/{session_name}.session").resolve()),
+        "TG_SESSION_PATH": read_session_path,
+        "TG_READ_SESSION_PATH": read_session_path,
+        "TG_ACTIONS_SESSION_PATH": actions_session_path,
+        "TG_SESSION_PATH_CONFLICT_MODE": "warn",
+        "TG_SESSION_CONFLICT_REGISTRY_FILE": str(
+            (repo / "data/anti_spam/session_registry.json").resolve()
+        ),
         "TG_ALLOW_SESSION_SWITCH": "0",
         "TG_BLOCK_DIRECT_TELETHON_WRITE": "1",
         "TG_ALLOW_DIRECT_TELETHON_WRITE": "0",
@@ -25,6 +35,7 @@ def _build_read_server(
         "TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS": "actions_mcp",
         "TG_WRITE_CONTEXT": "read_mcp",
         "TG_ACTION_PROCESS": "0",
+        "TG_SESSION_RUNTIME_MODE": "copy",
         "TG_RECEIVE_UPDATES": "0",
         "TG_SESSION_LOCK_MODE": "shared",
         "TG_GLOBAL_RPS_MODE": "shared",
@@ -47,12 +58,21 @@ def _build_actions_server(
     repo: Path,
     server_name: str,
     session_name: str,
+    read_session_name: str,
     expected_username: str = "",
 ) -> dict:
+    actions_session_path = str((repo / f"data/sessions/{session_name}.session").resolve())
+    read_session_path = str((repo / f"data/sessions/{read_session_name}.session").resolve())
     env = {
         "PYTHONPATH": f"{(repo / 'tganalytics').resolve()}:{repo.resolve()}",
         "TG_SESSIONS_DIR": str((repo / "data/sessions").resolve()),
-        "TG_SESSION_PATH": str((repo / f"data/sessions/{session_name}.session").resolve()),
+        "TG_SESSION_PATH": actions_session_path,
+        "TG_READ_SESSION_PATH": read_session_path,
+        "TG_ACTIONS_SESSION_PATH": actions_session_path,
+        "TG_SESSION_PATH_CONFLICT_MODE": "warn",
+        "TG_SESSION_CONFLICT_REGISTRY_FILE": str(
+            (repo / "data/anti_spam/session_registry.json").resolve()
+        ),
         "TG_ALLOW_SESSION_SWITCH": "0",
         "TG_ACTIONS_ENABLED": "1",
         "TG_ACTIONS_REQUIRE_ALLOWLIST": "1",
@@ -110,7 +130,7 @@ def main() -> int:
     )
     parser.add_argument("--read-server-name", default="tgmcp-read")
     parser.add_argument("--actions-server-name", default="tgmcp-actions")
-    parser.add_argument("--read-session-name", default="read_only_session")
+    parser.add_argument("--read-session-name", default="read_only_ro")
     parser.add_argument("--actions-session-name", default="actions_session")
     parser.add_argument(
         "--expected-username",
@@ -122,11 +142,21 @@ def main() -> int:
 
     repo = Path(args.repo).expanduser().resolve()
     servers = {}
+    read_session_path = str((repo / f"data/sessions/{args.read_session_name}.session").resolve())
+    actions_session_path = str((repo / f"data/sessions/{args.actions_session_name}.session").resolve())
+    if args.profile == "full" and read_session_path == actions_session_path:
+        print(
+            "[tg-mcp][session-warning] read/actions resolve to the same session file. "
+            "This is supported but not recommended for routine concurrent MCP traffic. "
+            "Prefer read -> *_ro.session and actions -> write session.",
+            file=sys.stderr,
+        )
     servers.update(
         _build_read_server(
             repo,
             args.read_server_name,
             args.read_session_name,
+            args.actions_session_name,
             expected_username=args.expected_username,
         )
     )
@@ -136,6 +166,7 @@ def main() -> int:
                 repo,
                 args.actions_server_name,
                 args.actions_session_name,
+                args.read_session_name,
                 expected_username=args.expected_username,
             )
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 Pytest configuration for tg-mcp tests
 """
 
+import os
 import sys
 from pathlib import Path
 import pytest
@@ -15,6 +16,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 TGANALYTICS_PKG = REPO_ROOT / "tganalytics"
 if str(TGANALYTICS_PKG) not in sys.path:
     sys.path.insert(0, str(TGANALYTICS_PKG))
+
+# Some modules validate Telegram API creds at import time; keep test collection hermetic.
+os.environ.setdefault("TG_API_ID", "1")
+os.environ.setdefault("TG_API_HASH", "testhash")
 
 class AsyncIteratorMock:
     """Мок для асинхронного итератора"""

--- a/tests/test_mcp_server_common_account_guard.py
+++ b/tests/test_mcp_server_common_account_guard.py
@@ -65,3 +65,82 @@ async def test_auth_status_reports_mismatch_as_unauthorized(monkeypatch):
 
     assert payload["authorized"] is False
     assert "Session mismatch" in payload.get("error", "")
+    assert "session_path_status" in payload
+
+
+def test_detect_declared_session_conflict_same_paths(monkeypatch, tmp_path):
+    session_path = str((tmp_path / "dmatskevich.session").resolve())
+    monkeypatch.setenv("TG_READ_SESSION_PATH", session_path)
+    monkeypatch.setenv("TG_ACTIONS_SESSION_PATH", session_path)
+
+    issue = common._detect_declared_session_conflict("read", session_path)
+
+    assert issue is not None
+    assert issue["read_session_path"] == session_path
+    assert "database is locked" in issue["message"]
+
+
+def test_context_fail_fast_on_same_session_conflict(monkeypatch, tmp_path):
+    session_path = str((tmp_path / "dmatskevich.session").resolve())
+    monkeypatch.setenv("TG_SESSION_PATH", session_path)
+    monkeypatch.setenv("TG_READ_SESSION_PATH", session_path)
+    monkeypatch.setenv("TG_ACTIONS_SESSION_PATH", session_path)
+    monkeypatch.setenv("TG_SESSION_PATH_CONFLICT_MODE", "fail")
+
+    with pytest.raises(RuntimeError, match="database is locked"):
+        common.MCPServerContext(allow_session_switch=False, server_profile="actions")
+
+
+def test_detect_live_session_conflict_same_profile_same_session(monkeypatch, tmp_path):
+    session_path = str((tmp_path / "dmatskevich_ro.session").resolve())
+    registry_file = tmp_path / "session_registry.json"
+    registry_file.write_text(
+        (
+            '{"claims": {'
+            '"read:111": {'
+            '"pid": 111, '
+            '"profile": "read", '
+            f'"session_path": "{session_path}", '
+            '"updated_at": 1'
+            "}"
+            "}}"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(common, "_is_pid_alive", lambda pid: int(pid) == 111)
+
+    issue = common._detect_live_session_conflict(
+        registry_file,
+        server_profile="read",
+        session_path=session_path,
+        own_claim_id="read:222",
+    )
+
+    assert issue is not None
+    assert issue["other_profile"] == "read"
+    assert "Multiple live 'read' MCP processes" in issue["message"]
+
+
+def test_session_path_status_reports_effective_runtime_copy(monkeypatch, tmp_path):
+    session_path = str((tmp_path / "dmatskevich_ro.session").resolve())
+    runtime_path = str((tmp_path / "runtime" / "shadow.session").resolve())
+
+    monkeypatch.setenv("TG_SESSION_PATH", session_path)
+    monkeypatch.setenv("TG_SESSION_PATH_CONFLICT_MODE", "off")
+    monkeypatch.setattr(
+        common,
+        "describe_session_target",
+        lambda _: {
+            "mode": "copy",
+            "source_session_file": session_path,
+            "effective_session_file": runtime_path,
+            "runtime_dir": str((tmp_path / "runtime").resolve()),
+        },
+    )
+
+    ctx = common.MCPServerContext(allow_session_switch=False, server_profile="read")
+    payload = ctx.session_path_status()
+
+    assert payload["session_path"] == session_path
+    assert payload["effective_session_path"] == runtime_path
+    assert payload["session_runtime_mode"] == "copy"

--- a/tests/test_session_path_preflight.py
+++ b/tests/test_session_path_preflight.py
@@ -1,0 +1,52 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_session_paths.py"
+
+
+def test_preflight_script_rejects_same_session_paths(tmp_path):
+    session_path = str((tmp_path / "dmatskevich.session").resolve())
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--read-session-path",
+            session_path,
+            "--actions-session-path",
+            session_path,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "share one Telegram session file" in result.stderr
+
+
+def test_preflight_script_accepts_separate_paths_from_config(tmp_path):
+    config_path = tmp_path / ".mcp.json"
+    payload = {
+        "mcpServers": {
+            "tgmcp-read": {
+                "env": {"TG_SESSION_PATH": str((tmp_path / "dmatskevich_ro.session").resolve())}
+            },
+            "tgmcp-actions": {
+                "env": {"TG_SESSION_PATH": str((tmp_path / "dmatskevich.session").resolve())}
+            },
+        }
+    }
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--config", str(config_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "use separate session files" in result.stdout

--- a/tests/test_tele_client_write_guard.py
+++ b/tests/test_tele_client_write_guard.py
@@ -1,4 +1,6 @@
 import os
+import sqlite3
+from pathlib import Path
 
 os.environ.setdefault("TG_API_ID", "1")
 os.environ.setdefault("TG_API_HASH", "testhash")
@@ -121,3 +123,50 @@ def test_get_client_disables_updates_loop_by_default(monkeypatch, tmp_path):
     tele_client.get_client()
 
     assert captured["kwargs"]["receive_updates"] is False
+
+
+def test_describe_session_target_uses_runtime_copy_for_existing_session(monkeypatch, tmp_path):
+    source = tmp_path / "dmatskevich_ro.session"
+    source.write_text("seed", encoding="utf-8")
+
+    monkeypatch.setattr(tele_client, "SESSION_RUNTIME_MODE", "copy")
+    monkeypatch.setattr(tele_client, "SESSION_RUNTIME_DIR", tmp_path / "runtime")
+
+    target = tele_client.describe_session_target(str(source))
+
+    assert target["mode"] == "copy"
+    assert target["source_session_file"] == str(source.resolve())
+    assert target["effective_session_file"] != str(source.resolve())
+    assert target["effective_session_file"].startswith(str((tmp_path / "runtime").resolve()))
+
+
+def test_get_client_for_session_uses_runtime_copy_when_enabled(monkeypatch, tmp_path):
+    source = tmp_path / "dmatskevich_ro.session"
+    with sqlite3.connect(str(source)) as conn:
+        conn.execute("create table version (value text)")
+        conn.execute("insert into version values ('shadow-copy-ok')")
+        conn.commit()
+
+    captured = {}
+
+    class DummyClient:
+        def __init__(self, session, api_id, api_hash, **kwargs):
+            captured["session"] = session
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(tele_client, "_clients_by_path", {})
+    monkeypatch.setattr(tele_client, "_runtime_session_files", set())
+    monkeypatch.setattr(tele_client, "SESSION_RUNTIME_MODE", "copy")
+    monkeypatch.setattr(tele_client, "SESSION_RUNTIME_DIR", tmp_path / "runtime")
+    monkeypatch.setattr(tele_client, "_acquire_session_lock", lambda *_: None)
+    monkeypatch.setattr(tele_client, "_harden_session_storage", lambda *_: None)
+    monkeypatch.setattr(tele_client, "GuardedTelegramClient", DummyClient)
+
+    tele_client.get_client_for_session(str(source))
+
+    runtime_session_file = Path(captured["session"]).with_suffix(".session")
+    with sqlite3.connect(str(runtime_session_file)) as conn:
+        value = conn.execute("select value from version").fetchone()[0]
+
+    assert value == "shadow-copy-ok"
+    assert runtime_session_file != source.resolve()

--- a/tganalytics/mcp_server_actions.py
+++ b/tganalytics/mcp_server_actions.py
@@ -136,7 +136,7 @@ def _parse_allowlist(raw: str) -> set[str]:
 ALLOWED_TARGETS = _parse_allowlist(os.environ.get("TG_ACTIONS_ALLOWED_GROUPS", ""))
 
 mcp = FastMCP(SERVER_NAME)
-ctx = MCPServerContext(allow_session_switch=ALLOW_SESSION_SWITCH)
+ctx = MCPServerContext(allow_session_switch=ALLOW_SESSION_SWITCH, server_profile="actions")
 
 
 def _check_target_allowed(group: str) -> tuple[bool, str | None]:
@@ -1229,6 +1229,7 @@ async def tg_run_add_member_batch(batch_id: str, max_actions: int = 100) -> dict
 async def tg_get_actions_policy() -> dict[str, Any]:
     """Return active action policy gates and limits."""
     limiter_stats = get_rate_limiter().get_stats()
+    session_path_status = ctx.session_path_status()
     return {
         "server_profile": "actions",
         "actions_enabled": ACTIONS_ENABLED,
@@ -1259,6 +1260,8 @@ async def tg_get_actions_policy() -> dict[str, Any]:
         "destructive_actions_require_confirm": True,
         "default_dry_run_for_member_actions": True,
         "allow_session_switch": ALLOW_SESSION_SWITCH,
+        "session_path_status": session_path_status,
+        "session_path_conflict": session_path_status.get("conflict"),
         "recommended_write_flow": [
             "1) Call write tool with dry_run=true to preview and get approval_code.",
             "2) Ask user for exact confirmation_text phrase in this thread.",

--- a/tganalytics/mcp_server_common.py
+++ b/tganalytics/mcp_server_common.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import glob
 import os
+import sys
+import time
 from typing import Any
 from pathlib import Path
 
@@ -11,8 +13,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+from mcp_actions_state import load_json_dict, update_json_dict
 from tganalytics.domain.groups import GroupManager
-from tganalytics.infra.tele_client import get_client, get_client_for_session
+from tganalytics.infra.tele_client import describe_session_target, get_client, get_client_for_session
 
 
 def _expected_username() -> str:
@@ -42,19 +45,191 @@ def _validate_expected_account(me: Any) -> str | None:
     return None
 
 
+def _resolve_session_path(raw_path: str) -> str:
+    raw = str(raw_path or "").strip()
+    if not raw:
+        return ""
+    return str(Path(raw).expanduser().resolve())
+
+
+def _normalize_session_conflict_mode(raw_mode: str) -> str:
+    mode = str(raw_mode or "").strip().lower()
+    if mode in {"off", "warn", "fail"}:
+        return mode
+    return "warn"
+
+
+def _session_conflict_registry_file() -> Path:
+    raw = os.environ.get("TG_SESSION_CONFLICT_REGISTRY_FILE", "").strip()
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return Path("data/anti_spam/session_registry.json").resolve()
+
+
+def _is_pid_alive(pid: Any) -> bool:
+    try:
+        value = int(pid)
+    except Exception:
+        return False
+    if value <= 0:
+        return False
+    try:
+        os.kill(value, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except Exception:
+        return True
+    return True
+
+
+def _declared_session_paths(server_profile: str, session_path: str) -> tuple[str, str]:
+    read_path = _resolve_session_path(os.environ.get("TG_READ_SESSION_PATH", ""))
+    actions_path = _resolve_session_path(os.environ.get("TG_ACTIONS_SESSION_PATH", ""))
+    if not read_path and server_profile == "read":
+        read_path = session_path
+    if not actions_path and server_profile == "actions":
+        actions_path = session_path
+    return read_path, actions_path
+
+
+def _build_declared_session_conflict_message(session_path: str) -> str:
+    return (
+        f"Read/Actions share one Telegram session file: {session_path}. "
+        "Concurrent Telethon read+write processes can hit sqlite 'database is locked'. "
+        "Prefer separate sessions by default: read -> *_ro.session, actions -> write session."
+    )
+
+
+def _build_live_session_conflict_message(
+    session_path: str,
+    *,
+    server_profile: str,
+    other_profile: str,
+) -> str:
+    if other_profile == server_profile:
+        return (
+            f"Multiple live '{server_profile}' MCP processes share one Telegram session file: {session_path}. "
+            "This is known to cause sqlite 'database is locked' under concurrent MCP traffic. "
+            "Use a dedicated session file per MCP client or stop the duplicate process."
+        )
+    return (
+        f"Read/Actions share one live Telegram session file: {session_path}. "
+        "This is known to cause sqlite 'database is locked' under concurrent MCP traffic. "
+        "Split sessions: read -> *_ro.session, actions -> write session."
+    )
+
+
+def _detect_declared_session_conflict(server_profile: str, session_path: str) -> dict[str, Any] | None:
+    read_path, actions_path = _declared_session_paths(server_profile, session_path)
+    if not read_path or not actions_path or read_path != actions_path:
+        return None
+    return {
+        "kind": "same_session_path",
+        "source": "declared_paths",
+        "message": _build_declared_session_conflict_message(read_path),
+        "read_session_path": read_path,
+        "actions_session_path": actions_path,
+    }
+
+
+def _register_session_claim(
+    registry_file: Path,
+    *,
+    server_profile: str,
+    session_path: str,
+) -> str:
+    claim_id = f"{server_profile}:{os.getpid()}"
+    claim = {
+        "pid": os.getpid(),
+        "profile": server_profile,
+        "session_path": session_path,
+        "updated_at": int(time.time()),
+    }
+
+    def _mut(claims: dict[str, Any]) -> None:
+        stale_keys = []
+        for key, value in claims.items():
+            pid = value.get("pid") if isinstance(value, dict) else None
+            if not _is_pid_alive(pid):
+                stale_keys.append(key)
+        for key in stale_keys:
+            claims.pop(key, None)
+        claims[claim_id] = claim
+
+    update_json_dict(registry_file, _mut, root_key="claims")
+    return claim_id
+
+
+def _detect_live_session_conflict(
+    registry_file: Path,
+    *,
+    server_profile: str,
+    session_path: str,
+    own_claim_id: str,
+) -> dict[str, Any] | None:
+    if not session_path:
+        return None
+    claims = load_json_dict(registry_file, root_key="claims")
+    for claim_id, value in claims.items():
+        if claim_id == own_claim_id or not isinstance(value, dict):
+            continue
+        other_profile = str(value.get("profile") or "").strip().lower()
+        other_session_path = _resolve_session_path(value.get("session_path", ""))
+        if other_session_path != session_path:
+            continue
+        if not _is_pid_alive(value.get("pid")):
+            continue
+        return {
+            "kind": "same_session_path",
+            "source": "live_registry",
+            "message": _build_live_session_conflict_message(
+                session_path,
+                server_profile=server_profile,
+                other_profile=other_profile,
+            ),
+            "read_session_path": session_path,
+            "actions_session_path": session_path,
+            "other_profile": other_profile,
+            "other_pid": value.get("pid"),
+        }
+    return None
+
+
 class MCPServerContext:
     """Shared runtime state for MCP servers.
 
     Keeps one active Telegram client/session per server process.
     """
 
-    def __init__(self, sessions_dir: str | None = None, allow_session_switch: bool = True):
+    def __init__(
+        self,
+        sessions_dir: str | None = None,
+        allow_session_switch: bool = True,
+        server_profile: str = "read",
+    ):
         self.sessions_dir = sessions_dir or os.environ.get("TG_SESSIONS_DIR", "data/sessions")
         self.allow_session_switch = allow_session_switch
+        self.server_profile = server_profile
 
         self._client = None
         self._manager: GroupManager | None = None
         self._current_session: str | None = None
+        self._current_session_path = ""
+        self._current_effective_session_path = ""
+        self._session_runtime_mode = "direct"
+        self._session_conflict_mode = _normalize_session_conflict_mode(
+            os.environ.get("TG_SESSION_PATH_CONFLICT_MODE", "warn")
+        )
+        self._session_conflict_registry_file = _session_conflict_registry_file()
+        self._last_session_conflict_message: str | None = None
+        self._session_conflict: dict[str, Any] | None = None
+        self._session_claim_id: str | None = None
+        self._registered_session_path: str | None = None
+
+        self._set_current_session_path(os.environ.get("TG_SESSION_PATH", ""))
+        self._enforce_session_path_policy()
 
     @property
     def current_session(self) -> str | None:
@@ -64,7 +239,73 @@ class MCPServerContext:
     def client(self) -> Any:
         return self._client
 
+    def _set_current_session_path(self, session_path: str) -> None:
+        resolved = _resolve_session_path(session_path)
+        self._current_session_path = resolved
+        self._current_effective_session_path = resolved
+        self._session_runtime_mode = "direct"
+        if not resolved:
+            return
+
+        target = describe_session_target(resolved)
+        self._current_session_path = target["source_session_file"]
+        self._current_effective_session_path = target["effective_session_file"]
+        self._session_runtime_mode = target["mode"]
+
+    def _ensure_session_claim(self) -> None:
+        session_path = self._current_effective_session_path or self._current_session_path
+        if self._session_conflict_mode == "off" or not session_path:
+            return
+        if self._registered_session_path == session_path and self._session_claim_id:
+            return
+        self._session_claim_id = _register_session_claim(
+            self._session_conflict_registry_file,
+            server_profile=self.server_profile,
+            session_path=session_path,
+        )
+        self._registered_session_path = session_path
+
+    def _enforce_session_path_policy(self) -> dict[str, Any] | None:
+        session_path = self._current_session_path
+        effective_session_path = self._current_effective_session_path or session_path
+        issue = _detect_declared_session_conflict(self.server_profile, session_path)
+        if issue is None and effective_session_path and self._session_conflict_mode != "off":
+            self._ensure_session_claim()
+            issue = _detect_live_session_conflict(
+                self._session_conflict_registry_file,
+                server_profile=self.server_profile,
+                session_path=effective_session_path,
+                own_claim_id=self._session_claim_id or "",
+            )
+
+        self._session_conflict = issue
+        if not issue or self._session_conflict_mode == "off":
+            return issue
+
+        message = issue["message"]
+        if self._session_conflict_mode == "fail":
+            raise RuntimeError(message)
+        if message != self._last_session_conflict_message:
+            print(f"[tg-mcp][session-warning] {message}", file=sys.stderr)
+            self._last_session_conflict_message = message
+        return issue
+
+    def session_path_status(self) -> dict[str, Any]:
+        issue = self._enforce_session_path_policy()
+        read_path, actions_path = _declared_session_paths(self.server_profile, self._current_session_path)
+        return {
+            "server_profile": self.server_profile,
+            "mode": self._session_conflict_mode,
+            "session_path": self._current_session_path or None,
+            "effective_session_path": self._current_effective_session_path or None,
+            "session_runtime_mode": self._session_runtime_mode,
+            "declared_read_session_path": read_path or None,
+            "declared_actions_session_path": actions_path or None,
+            "conflict": issue,
+        }
+
     async def _connect_client(self, client, session_name: str) -> GroupManager:
+        self._enforce_session_path_policy()
         await client.connect()
         if not await client.is_user_authorized():
             await client.disconnect()
@@ -90,6 +331,7 @@ class MCPServerContext:
         if self._manager is None:
             session_path = os.environ.get("TG_SESSION_PATH", "").strip()
             if session_path:
+                self._set_current_session_path(session_path)
                 session_name = os.path.basename(session_path).replace(".session", "")
                 client = get_client_for_session(session_path)
             else:
@@ -122,6 +364,8 @@ class MCPServerContext:
             await self._client.disconnect()
 
         try:
+            self._set_current_session_path(path)
+            self._enforce_session_path_policy()
             client = get_client_for_session(path)
             await self._connect_client(client, session_name)
             me = await self._client.get_me()
@@ -136,6 +380,8 @@ class MCPServerContext:
         session_path = os.environ.get("TG_SESSION_PATH", "").strip()
         if session_path:
             resolved_path = str(Path(session_path).expanduser().resolve())
+            self._set_current_session_path(resolved_path)
+            self._enforce_session_path_policy()
             session_name = Path(session_path).name.replace(".session", "")
             client = self._client or get_client_for_session(session_path)
             is_transient = self._client is None
@@ -152,6 +398,7 @@ class MCPServerContext:
                 "authorized": bool(authorized),
                 "session_name": session_name,
                 "session_path": resolved_path or None,
+                "session_path_status": self.session_path_status(),
             }
             if authorized:
                 me = await client.get_me()
@@ -170,6 +417,7 @@ class MCPServerContext:
                 "authorized": False,
                 "session_name": session_name,
                 "session_path": resolved_path or None,
+                "session_path_status": self.session_path_status(),
                 "error": str(exc),
             }
         finally:

--- a/tganalytics/mcp_server_read.py
+++ b/tganalytics/mcp_server_read.py
@@ -15,6 +15,7 @@ os.environ.setdefault("TG_ENFORCE_ACTION_PROCESS", "1")
 os.environ.setdefault("TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS", "actions_mcp")
 os.environ.setdefault("TG_WRITE_CONTEXT", "read_mcp")
 os.environ.setdefault("TG_ACTION_PROCESS", "0")
+os.environ.setdefault("TG_SESSION_RUNTIME_MODE", "copy")
 
 from mcp.server.fastmcp import FastMCP
 
@@ -26,7 +27,7 @@ SERVER_NAME = os.environ.get("TG_MCP_SERVER_NAME", "tganalytics-read")
 ALLOW_SESSION_SWITCH = os.environ.get("TG_ALLOW_SESSION_SWITCH", "1") == "1"
 
 mcp = FastMCP(SERVER_NAME)
-ctx = MCPServerContext(allow_session_switch=ALLOW_SESSION_SWITCH)
+ctx = MCPServerContext(allow_session_switch=ALLOW_SESSION_SWITCH, server_profile="read")
 
 
 @mcp.tool()

--- a/tganalytics/tganalytics/infra/tele_client.py
+++ b/tganalytics/tganalytics/infra/tele_client.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 import os
 import asyncio
 import atexit
+import hashlib
+import shutil
 import shlex
+import sqlite3
 import subprocess
 import sys
 from pathlib import Path
@@ -42,6 +47,22 @@ WRITE_ALLOWED_CONTEXTS = {
     for item in os.getenv("TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS", "actions_mcp").split(",")
     if item.strip()
 }
+SESSION_RUNTIME_MODE = os.getenv("TG_SESSION_RUNTIME_MODE", "direct").strip().lower()
+if SESSION_RUNTIME_MODE in {"shadow", "shadow_copy"}:
+    SESSION_RUNTIME_MODE = "copy"
+if SESSION_RUNTIME_MODE not in {"direct", "copy"}:
+    SESSION_RUNTIME_MODE = "direct"
+SESSION_RUNTIME_PROFILE = (
+    os.getenv("TG_SESSION_RUNTIME_PROFILE", "").strip().lower()
+    or WRITE_CONTEXT
+    or "default"
+)
+SESSION_RUNTIME_DIR = Path(
+    os.getenv(
+        "TG_SESSION_RUNTIME_DIR",
+        str((SESSION_DIR / "runtime" / SESSION_RUNTIME_PROFILE).resolve()),
+    )
+)
 
 READ_REQUEST_PREFIXES = (
     "Get",
@@ -202,6 +223,7 @@ if not api_id or not api_hash:
 _client = None
 _clients_by_path = {}
 _session_lock_fds = {}
+_runtime_session_files = set()
 
 
 def _normalize_session_file_path(path: Path) -> Path:
@@ -209,6 +231,88 @@ def _normalize_session_file_path(path: Path) -> Path:
     if path.suffix == ".session":
         return path
     return path.with_suffix(".session")
+
+
+def _runtime_safe_component(value: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in value)
+    return cleaned.strip("_") or "session"
+
+
+def _runtime_session_file(source_session_file: Path) -> Path:
+    source = _normalize_session_file_path(source_session_file).expanduser().resolve()
+    digest = hashlib.sha1(str(source).encode("utf-8")).hexdigest()[:10]
+    stem = _runtime_safe_component(source.stem)
+    return (SESSION_RUNTIME_DIR / f"{stem}__{digest}__pid{os.getpid()}.session").resolve()
+
+
+def describe_session_target(session_file: str | Path) -> dict[str, str]:
+    """Describe canonical vs effective session file for the current process."""
+    source = _normalize_session_file_path(Path(session_file)).expanduser().resolve()
+    effective = source
+    if SESSION_RUNTIME_MODE == "copy" and source.exists():
+        effective = _runtime_session_file(source)
+    return {
+        "mode": SESSION_RUNTIME_MODE,
+        "source_session_file": str(source),
+        "effective_session_file": str(effective),
+        "runtime_dir": str(SESSION_RUNTIME_DIR.resolve()),
+    }
+
+
+def _copy_session_sidecars(source: Path, target: Path) -> None:
+    for suffix in ("-journal", "-wal", "-shm"):
+        source_companion = Path(f"{source}{suffix}")
+        target_companion = Path(f"{target}{suffix}")
+        if source_companion.exists():
+            shutil.copy2(source_companion, target_companion)
+
+
+def _prepare_runtime_session_copy(source_session_file: Path, effective_session_file: Path) -> None:
+    if source_session_file == effective_session_file or not source_session_file.exists():
+        return
+
+    SESSION_RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+    target_key = str(effective_session_file.resolve())
+    if target_key in _runtime_session_files and effective_session_file.exists():
+        return
+
+    for suffix in ("", "-journal", "-wal", "-shm"):
+        candidate = Path(f"{effective_session_file}{suffix}")
+        if candidate.exists():
+            candidate.unlink()
+
+    try:
+        with sqlite3.connect(
+            f"file:{source_session_file.resolve()}?mode=ro",
+            uri=True,
+            timeout=30,
+        ) as source_conn:
+            with sqlite3.connect(str(effective_session_file), timeout=30) as target_conn:
+                source_conn.backup(target_conn)
+                target_conn.commit()
+    except Exception:
+        shutil.copy2(source_session_file, effective_session_file)
+        _copy_session_sidecars(source_session_file, effective_session_file)
+
+    _runtime_session_files.add(target_key)
+
+
+def _cleanup_runtime_session_files() -> None:
+    for runtime_session in list(_runtime_session_files):
+        runtime_path = Path(runtime_session)
+        for suffix in ("", "-journal", "-wal", "-shm", ".lock"):
+            candidate = (
+                runtime_path.with_suffix(runtime_path.suffix + suffix)
+                if suffix == ".lock"
+                else Path(f"{runtime_path}{suffix}")
+            )
+            if not candidate.exists():
+                continue
+            try:
+                candidate.unlink()
+            except Exception:
+                pass
+        _runtime_session_files.discard(runtime_session)
 
 
 def _is_direct_write_allowed() -> bool:
@@ -352,15 +456,27 @@ def _acquire_session_lock(session_file: Path) -> None:
 
 
 atexit.register(_release_session_locks)
+atexit.register(_cleanup_runtime_session_files)
 
 def get_client():
     global _client
     if _client is None:
-        session_file = _normalize_session_file_path(Path(session_path))
+        target = describe_session_target(session_path)
+        source_session_file = Path(target["source_session_file"])
+        session_file = Path(target["effective_session_file"])
+        _prepare_runtime_session_copy(source_session_file, session_file)
         _acquire_session_lock(session_file)
         # Усиливаем права хранилища перед созданием клиента
-        _harden_session_storage(SESSION_DIR, session_file)
-        _client = GuardedTelegramClient(session_path, api_id, api_hash, receive_updates=RECEIVE_UPDATES)
+        _harden_session_storage(session_file.parent, session_file)
+        runtime_session_name = (
+            str(session_file.with_suffix("")) if session_file.suffix == ".session" else str(session_file)
+        )
+        _client = GuardedTelegramClient(
+            runtime_session_name,
+            api_id,
+            api_hash,
+            receive_updates=RECEIVE_UPDATES,
+        )
     return _client
 
 def get_client_for_session(custom_session_file_path: str):
@@ -370,9 +486,11 @@ def get_client_for_session(custom_session_file_path: str):
     """
     if not custom_session_file_path:
         return get_client()
-    session_file = Path(custom_session_file_path)
-    normalized_session_file = _normalize_session_file_path(session_file)
-    session_dir = session_file.parent
+    target = describe_session_target(custom_session_file_path)
+    source_session_file = Path(target["source_session_file"])
+    normalized_session_file = Path(target["effective_session_file"])
+    _prepare_runtime_session_copy(source_session_file, normalized_session_file)
+    session_dir = normalized_session_file.parent
     session_dir.mkdir(parents=True, exist_ok=True)
     _acquire_session_lock(normalized_session_file)
     # Усиливаем права


### PR DESCRIPTION
## What changed
- isolate `tgmcp-read` session usage per process with `TG_SESSION_RUNTIME_MODE=copy`, so duplicate Codex read clients no longer contend on one Telethon sqlite session
- surface canonical vs effective session paths in `tg_auth_status` / session diagnostics and fail fast on same-profile live conflicts
- add session-path preflight tooling plus docs for the recommended topology: read -> `*_ro.session`, actions -> write session
- add regression coverage for runtime-copy behavior, live same-session conflict detection, and config preflight

## Why
The real failure mode was topology, not account auth: multiple live `tgmcp-read` processes could sit on the same sqlite session file and hit `database is locked`. A one-off `_ro_copy.session` workaround reduces pain, but the durable fix is per-process runtime ownership of the read session plus explicit conflict diagnostics.

## Impact
- read MCP becomes stable under multiple Codex clients / duplicate read processes
- operators get clearer session diagnostics before traffic starts
- setup docs and generated config now describe the intended session split instead of an implicit shared-file model

## Validation
- `PYTHONPATH=tganalytics:. python3 -m pytest tests/test_tele_client_write_guard.py tests/test_mcp_server_common_account_guard.py tests/test_session_path_preflight.py -q`
- `bash scripts/check_tg_mcp.sh /Users/dmitrymatskevich/tg-mcp /Users/dmitrymatskevich/tg-mcp/.mcp.json`
- shell `auth_status` probe for `@dmatskevich` returned `authorized=true` with `session_runtime_mode=copy` and `conflict=null`

## Notes
- local Codex client configs outside the repo were updated separately and are intentionally not part of this PR
- mixed unrelated worktree changes were left untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session-file handling by introducing per-process runtime session copies and new conflict detection/registry logic; misconfiguration could prevent MCP startup or break session reuse across processes.
> 
> **Overview**
> Improves MCP session concurrency by defaulting `tgmcp-read` to `TG_SESSION_RUNTIME_MODE=copy`, creating a per-process runtime copy of the Telethon sqlite `.session` to reduce `database is locked` collisions.
> 
> Adds session-path diagnostics and enforcement in `MCPServerContext`: `tg_auth_status`/`tg_get_actions_policy` now surface `session_path_status` (canonical vs effective paths) and can warn/fail when read/actions (or multiple live same-profile processes) share a session file via `TG_SESSION_PATH_CONFLICT_MODE` and a JSON registry.
> 
> Updates generated/sample configs and docs to recommend splitting read (`*_ro.session`) vs actions sessions, adds a `scripts/check_session_paths.py` preflight and hooks it into `check_tg_mcp.sh`, and extends tests/CI env defaults to cover the new runtime-copy + conflict checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f34950ff0693453caf7a949b6858030f115e20c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->