### PR TITLE
docs: add developer setup and pre-PR check shortcut to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ cp .env.sample .env
 PYTHONPATH=tganalytics:. python3 -m pytest tests/ -q
 ```
 
+## Developer Setup Shortcut
+
+For local development, you can bootstrap everything (env sync, dependencies, and required data directories) with one command:
+
+```bash
+make dev-setup
+```
+
+Before opening a PR, run the standard repository checks:
+
+```bash
+make dev-check
+```
+
 ## Session Bootstrap (Auth)
 
 `read` profile remains write-safe, but initial Telegram login requires auth requests.


### PR DESCRIPTION
### Motivation
- Surface the repo's one-command bootstrap and the standard pre-PR quality gate so contributors can get started and prepare changes consistently.

### Description
- Add a new `Developer Setup Shortcut` section to `README.md` documenting `make dev-setup` for local bootstrap and `make dev-check` as the pre-PR check.

### Testing
- Ran `PYTHONPATH=tganalytics:. python3 -m pytest tests/core/test_arch_contracts.py -q` which passed (2 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0b80a3df48329891aa3dd4d937556)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds contributor guidance without affecting runtime behavior.
> 
> **Overview**
> Adds a new **Developer Setup Shortcut** section to `README.md` documenting `make dev-setup` for one-command local bootstrap and `make dev-check` as the standard pre-PR quality gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de0aa9dd8587ee6ebfd13d88745af52c622c975. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->