### PR TITLE
[codex] expand guarded telegram actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,15 @@ data/sessions/
 data/export/
 data/logs/
 data/anti_spam/
+data/downloads/
+data/*.html
+data/*.png
+tganalytics/data/
+
+# Local one-off analysis scripts
+scripts/analyze_chat.py
+scripts/visualize_chat.py
+scripts/visualize_chat_interactive.py
 
 # Python cache
 __pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,21 +62,95 @@ Read/Actions MCP tools для доступа к Telegram API:
 
 ## Использование из другого проекта
 
-Добавь в `.mcp.json` или `.claude/settings.json`:
+Предпочтительно подключать split-профили, а не legacy alias `telegram`/`tganalytics`.
+
+Добавь в `.mcp.json`:
 ```json
 {
   "mcpServers": {
-    "tganalytics": {
-      "command": "/Users/dmitrymatskevich/tg-mcp/venv/bin/python3",
-      "args": ["/Users/dmitrymatskevich/tg-mcp/tganalytics/mcp_server.py"],
+    "tgmcp-read": {
+      "command": "/absolute/path/to/tg-mcp/venv/bin/python3",
+      "args": [
+        "/absolute/path/to/tg-mcp/tganalytics/mcp_server_read.py"
+      ],
       "env": {
-        "PYTHONPATH": "/Users/dmitrymatskevich/tg-mcp/tganalytics:/Users/dmitrymatskevich/tg-mcp",
-        "TG_SESSIONS_DIR": "/Users/dmitrymatskevich/tg-mcp/data/sessions"
+        "PYTHONPATH": "/absolute/path/to/tg-mcp/tganalytics:/absolute/path/to/tg-mcp",
+        "TG_SESSIONS_DIR": "/absolute/path/to/tg-mcp/data/sessions",
+        "TG_SESSION_PATH": "/absolute/path/to/tg-mcp/data/sessions/my_account_ro.session",
+        "TG_ALLOW_SESSION_SWITCH": "0",
+        "TG_BLOCK_DIRECT_TELETHON_WRITE": "1",
+        "TG_ALLOW_DIRECT_TELETHON_WRITE": "0",
+        "TG_ENFORCE_ACTION_PROCESS": "1",
+        "TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS": "actions_mcp",
+        "TG_WRITE_CONTEXT": "read_mcp",
+        "TG_ACTION_PROCESS": "0",
+        "TG_RECEIVE_UPDATES": "0",
+        "TG_SESSION_LOCK_MODE": "shared",
+        "TG_GLOBAL_RPS_MODE": "shared",
+        "TG_FLOOD_CIRCUIT_THRESHOLD_SEC": "300",
+        "TG_FLOOD_CIRCUIT_COOLDOWN_SEC": "900",
+        "TG_EXPECTED_USERNAME": "my_account"
+      }
+    },
+    "tgmcp-actions": {
+      "command": "/absolute/path/to/tg-mcp/venv/bin/python3",
+      "args": [
+        "/absolute/path/to/tg-mcp/tganalytics/mcp_server_actions.py"
+      ],
+      "env": {
+        "PYTHONPATH": "/absolute/path/to/tg-mcp/tganalytics:/absolute/path/to/tg-mcp",
+        "TG_SESSIONS_DIR": "/absolute/path/to/tg-mcp/data/sessions",
+        "TG_SESSION_PATH": "/absolute/path/to/tg-mcp/data/sessions/my_account.session",
+        "TG_ALLOW_SESSION_SWITCH": "0",
+        "TG_ACTIONS_ENABLED": "1",
+        "TG_ACTIONS_REQUIRE_ALLOWLIST": "1",
+        "TG_ACTIONS_ALLOWED_GROUPS": "@your_allowed_target",
+        "TG_ACTIONS_MAX_MESSAGE_LEN": "2000",
+        "TG_ACTIONS_MAX_FILE_MB": "20",
+        "TG_ACTIONS_REQUIRE_CONFIRMATION_TEXT": "1",
+        "TG_ACTIONS_CONFIRMATION_PHRASE": "отправляй",
+        "TG_ACTIONS_MIN_CONFIRM_TEXT_LEN": "6",
+        "TG_ACTIONS_REQUIRE_APPROVAL_CODE": "1",
+        "TG_ACTIONS_APPROVAL_TTL_SEC": "1800",
+        "TG_ACTIONS_APPROVAL_MIN_AGE_SEC": "30",
+        "TG_ACTIONS_APPROVAL_FILE": "/absolute/path/to/tg-mcp/data/anti_spam/action_approvals.json",
+        "TG_ACTIONS_IDEMPOTENCY_ENABLED": "1",
+        "TG_ACTIONS_IDEMPOTENCY_WINDOW_SEC": "86400",
+        "TG_ACTIONS_IDEMPOTENCY_FILE": "/absolute/path/to/tg-mcp/data/anti_spam/action_idempotency.json",
+        "TG_ACTIONS_BATCH_FILE": "/absolute/path/to/tg-mcp/data/anti_spam/action_batches.json",
+        "TG_ACTIONS_BATCH_TTL_HOURS": "168",
+        "TG_ACTIONS_BATCH_APPROVAL_LEASE_SEC": "86400",
+        "TG_ACTIONS_BATCH_RUN_LEASE_SEC": "1800",
+        "TG_ACTIONS_UNSAFE_OVERRIDE": "0",
+        "TG_BLOCK_DIRECT_TELETHON_WRITE": "1",
+        "TG_ALLOW_DIRECT_TELETHON_WRITE": "0",
+        "TG_ENFORCE_ACTION_PROCESS": "1",
+        "TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS": "actions_mcp",
+        "TG_WRITE_CONTEXT": "actions_mcp",
+        "TG_ACTION_PROCESS": "1",
+        "TG_RECEIVE_UPDATES": "0",
+        "TG_SESSION_LOCK_MODE": "shared",
+        "TG_GLOBAL_RPS_MODE": "shared",
+        "TG_FLOOD_CIRCUIT_THRESHOLD_SEC": "300",
+        "TG_FLOOD_CIRCUIT_COOLDOWN_SEC": "900",
+        "MAX_GROUP_MSGS_PER_DAY": "30",
+        "TG_EXPECTED_USERNAME": "my_account"
       }
     }
   }
 }
 ```
+
+Если используешь claude-code, в `~/.claude/settings.local.json` или project `.claude/settings.local.json` включай именно:
+```json
+{
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["tgmcp-read", "tgmcp-actions"],
+  "disabledMcpjsonServers": ["telegram"]
+}
+```
+
+Иначе claude может подключить legacy alias `telegram` и увидеть только read-capability.
 
 ## Команды
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ cp .env.sample .env
 PYTHONPATH=tganalytics:. python3 -m pytest tests/ -q
 ```
 
+## Developer Setup Shortcut
+
+For local development, you can bootstrap everything (env sync, dependencies, and required data directories) with one command:
+
+```bash
+make dev-setup
+```
+
+Before opening a PR, run the standard repository checks:
+
+```bash
+make dev-check
+```
+
 ## Session Bootstrap (Auth)
 
 `read` profile remains write-safe, but initial Telegram login requires auth requests.
@@ -286,12 +300,13 @@ Add to your project's `.mcp.json`:
 |------|-------------|
 | `tg_list_sessions` | List available Telegram sessions |
 | `tg_use_session` | Switch active session |
-| `tg_get_group_info` | Get group/channel info |
+| `tg_get_group_info` | Get group/channel/direct dialog info |
 | `tg_get_participants` | Export group members |
 | `tg_search_participants` | Search members by query |
-| `tg_get_messages` | Export messages |
-| `tg_get_message_count` | Get message count |
-| `tg_get_group_creation_date` | Get group creation date |
+| `tg_get_messages` | Export messages from a dialog target |
+| `tg_get_messages_since` | Export messages newest-to-oldest until a cutoff date |
+| `tg_get_message_count` | Get dialog message count |
+| `tg_get_group_creation_date` | Get dialog first-message date |
 | `tg_get_my_dialogs` | List account dialogs |
 | `tg_resolve_username` | Resolve username to entity |
 | `tg_get_user_by_id` | Get user by numeric ID |
@@ -310,14 +325,23 @@ Add to your project's `.mcp.json`:
 | `tg_resolve_username` | Resolve target username |
 | `tg_send_message` | Send message with anti-spam + policy gates (`confirm=true` + exact `confirmation_text` + one-time `approval_code`) |
 | `tg_send_file` | Send local file with anti-spam + policy gates (`confirm=true` + exact `confirmation_text` + one-time `approval_code`) |
+| `tg_delete_messages` | Delete specific messages in a dialog/group (`dry_run` by default; same confirm + approval gates on execution) |
+| `tg_clear_history` | Clear dialog history with `DeleteHistoryRequest` (`dry_run` by default; same confirm + approval gates on execution) |
+| `tg_leave_dialog` | Leave an allowlisted channel/group (`dry_run` by default; same confirm + approval gates on execution) |
+| `tg_edit_message` | Edit a message in a dialog/group (`dry_run` by default; same confirm + approval gates on execution) |
+| `tg_forward_messages` | Forward messages between allowlisted dialogs (`dry_run` by default; same confirm + approval gates on execution) |
 | `tg_add_member_to_group` | Add user to group/channel (`dry_run` by default; same confirm + approval gates on execution) |
 | `tg_remove_member_from_group` | Remove user from group/channel (`dry_run` by default; same confirm + approval gates on execution) |
 | `tg_migrate_member` | Add new user + remove old user in one safe flow (same confirm + approval gates on execution) |
 | `tg_create_add_member_batch` | Build one add-member batch for many groups (single approval for whole task) |
 | `tg_create_add_member_batch_from_report` | Build batch from failed groups in JSON report |
+| `tg_create_delete_messages_batch_from_manifest` | Build delete batch from a reviewed privacy scrubber manifest |
+| `tg_create_leave_dialog_batch_from_candidates` | Build leave batch from reviewed channel candidates |
 | `tg_approve_batch` | One-time approve a batch |
 | `tg_get_batch_status` | Check batch progress and pending groups |
 | `tg_run_add_member_batch` | Run approved batch in chunks (no per-group approvals) |
+| `tg_run_delete_messages_batch` | Run approved delete batch in chunks |
+| `tg_run_leave_dialog_batch` | Run approved leave-dialog batch in chunks |
 | `tg_get_actions_policy` | Show active action restrictions |
 | `tg_get_stats` | Anti-spam system stats |
 | `tg_auth_status` | Check current session authorization status |
@@ -335,6 +359,7 @@ Add to your project's `.mcp.json`:
 - Set `TG_READ_SESSION_PATH` + `TG_ACTIONS_SESSION_PATH` in both server envs so runtime can warn/fail on same-session misconfig.
 - `TG_SESSION_PATH_CONFLICT_MODE=warn` prints startup/runtime warning; set `fail` to block server start on same-session conflict.
 - Run `python3 scripts/check_session_paths.py --config /path/to/.mcp.json` before enabling both servers.
+- If a Codex thread did not expose native `mcp__tgmcp_actions__*` tools, use `python3 scripts/tg_action_bridge.py ...` as a shell fallback. The bridge still talks to `mcp_server_actions.py` over MCP/JSON-RPC, defaults to `TG_SESSION_RUNTIME_MODE=copy`, and preserves the same allowlist/approval/confirm policy.
 - `TG_EXPECTED_USERNAME` enables fail-fast on session/account mismatch (`@expected` vs actual account in session).
 - `TG_RECEIVE_UPDATES=0` (default) disables Telethon updates loop to reduce sqlite session lock contention.
 - `TG_GLOBAL_RPS_MODE=shared` applies one shared RPS budget across all processes using the same `data/anti_spam`.
@@ -353,6 +378,20 @@ Add to your project's `.mcp.json`:
 - Use `tgmcp-actions` tools for any write operation.
 - In strict mode (`TG_ENFORCE_ACTION_PROCESS=1`), write is allowed only when process entrypoint is `mcp_server_actions.py`.
 - For hard session isolation, run MCP under a dedicated OS user and keep `data/sessions` owned by that user only.
+
+Fallback bridge examples:
+
+```bash
+# list tools from ~/.codex/config.toml server tgmcp_actions
+python3 scripts/tg_action_bridge.py tools
+
+# raw call
+python3 scripts/tg_action_bridge.py call tg_get_actions_policy --args-json '{}'
+
+# canonical write flow: dry_run -> approval_code -> confirm
+python3 scripts/tg_action_bridge.py write-call tg_send_message \
+  --args-json '{"group":"@mybot","message_text":"hello"}'
+```
 
 ## Structure
 

--- a/data/anti_spam/daily_counters.txt
+++ b/data/anti_spam/daily_counters.txt
@@ -1,5 +1,0 @@
-date=2026-01-28
-dm_count=0
-join_count=0
-api_calls=1
-flood_waits=0

--- a/docs/AGENT_PLAYBOOK.md
+++ b/docs/AGENT_PLAYBOOK.md
@@ -4,8 +4,8 @@ This guide is for AI agents and operators who need to work with `tg-mcp` quickly
 
 ## 1. Mental Model
 
-- `tgmcp-read`: analytics and discovery only (`tg_get_*`, `tg_list_sessions`, `tg_resolve_username`, etc.).
-- `tgmcp-actions`: any Telegram write (`tg_send_message`, `tg_send_file`, add/remove/migrate member).
+- `tgmcp-read`: analytics and discovery only (`tg_get_*`, `tg_get_messages_since`, `tg_list_sessions`, `tg_resolve_username`, etc.).
+- `tgmcp-actions`: any Telegram write (`tg_send_message`, `tg_send_file`, `tg_delete_messages`, `tg_clear_history`, `tg_leave_dialog`, `tg_edit_message`, `tg_forward_messages`, add/remove/migrate member).
 - Direct Telethon write is blocked by default outside Action MCP.
 - Session bootstrap auth is allowed only in explicit mode (`TG_AUTH_BOOTSTRAP=1`).
 - For new installations, prefer `read` profile first (`scripts/render_mcp_config.py --profile read`).
@@ -40,14 +40,22 @@ If any check fails, stop write execution and report policy mismatch.
 5. If duplicate blocked:
 - wait for window or use `force_resend=true` only if user explicitly asked to resend.
 
+Fallback when native ActionMCP tools are missing in the current thread:
+- use `python3 scripts/tg_action_bridge.py tools` to verify shell-side bridge access
+- use `python3 scripts/tg_action_bridge.py write-call ...` for write tools
+- the bridge still talks to `mcp_server_actions.py` over MCP/JSON-RPC and keeps allowlist/approval/confirm gates
+
 ## 4. Canonical Write Flow (Batch Mission)
 
-Use this when user wants one approval and then autonomous processing of many groups.
+Use this when user wants one approval and then autonomous processing of many groups or destructive cleanup chunks.
 
-1. `tg_create_add_member_batch(user, groups, note)`
+1. Create one batch:
+- add member: `tg_create_add_member_batch(user, groups, note)`
+- delete cleanup: `tg_create_delete_messages_batch_from_manifest(manifest_path)`
+- leave cleanup: `tg_create_leave_dialog_batch_from_candidates(candidates_path)`
 2. `tg_approve_batch(batch_id, confirmation_text)` once
 3. Loop:
-- `tg_run_add_member_batch(batch_id, max_actions=...)`
+- `tg_run_add_member_batch(batch_id, max_actions=...)`, `tg_run_delete_messages_batch(...)`, or `tg_run_leave_dialog_batch(...)`
 - `tg_get_batch_status(batch_id)` for progress
 4. If stopped by quota:
 - wait for quota reset, continue with `tg_run_add_member_batch`

--- a/scripts/tg_action_bridge.py
+++ b/scripts/tg_action_bridge.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""Fallback bridge for calling tg-mcp ActionMCP tools over stdio JSON-RPC.
+
+Use this when the current Codex thread does not expose native
+`mcp__tgmcp_actions__*` tools but shell access is still available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CONFIG_PATH = Path.home() / ".codex" / "config.toml"
+DEFAULT_SERVER_NAME = "tgmcp_actions"
+DEFAULT_PROTOCOL_VERSION = "2025-03-26"
+DEFAULT_RUNTIME_MODE = "copy"
+DEFAULT_RUNTIME_PROFILE = "actions_bridge"
+
+
+class BridgeError(RuntimeError):
+    """Bridge-specific failure with user-facing context."""
+
+
+@dataclass
+class ServerSpec:
+    name: str
+    command: str
+    args: list[str]
+    env: dict[str, str]
+    cwd: str | None = None
+
+
+def _normalize_server_candidates(name: str) -> list[str]:
+    raw = (name or DEFAULT_SERVER_NAME).strip()
+    if not raw:
+        raw = DEFAULT_SERVER_NAME
+    variants = [raw]
+    if "_" in raw:
+        variants.append(raw.replace("_", "-"))
+    if "-" in raw:
+        variants.append(raw.replace("-", "_"))
+    seen: list[str] = []
+    for item in variants:
+        if item and item not in seen:
+            seen.append(item)
+    return seen
+
+
+def load_server_spec(config_path: Path, server_name: str) -> ServerSpec:
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise BridgeError(f"Codex config not found: {config_path}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise BridgeError(f"Invalid TOML in config: {config_path}: {exc}") from exc
+
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        raise BridgeError(f"No [mcp_servers] section in {config_path}")
+
+    resolved_name = None
+    spec = None
+    for candidate in _normalize_server_candidates(server_name):
+        value = servers.get(candidate)
+        if isinstance(value, dict):
+            resolved_name = candidate
+            spec = value
+            break
+
+    if spec is None or resolved_name is None:
+        tried = ", ".join(_normalize_server_candidates(server_name))
+        raise BridgeError(
+            f"Action server '{server_name}' not found in {config_path} (tried: {tried})"
+        )
+
+    command = str(spec.get("command") or "").strip()
+    if not command:
+        raise BridgeError(f"Server '{resolved_name}' has no command in {config_path}")
+
+    args = spec.get("args") or []
+    if not isinstance(args, list):
+        raise BridgeError(f"Server '{resolved_name}' args must be a list")
+
+    env = spec.get("env") or {}
+    if not isinstance(env, dict):
+        raise BridgeError(f"Server '{resolved_name}' env must be a table")
+
+    cwd = spec.get("cwd")
+    return ServerSpec(
+        name=resolved_name,
+        command=command,
+        args=[str(item) for item in args],
+        env={str(key): str(value) for key, value in env.items()},
+        cwd=str(cwd).strip() or None if cwd is not None else None,
+    )
+
+
+def parse_env_overrides(values: list[str]) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for item in values:
+        if "=" not in item:
+            raise BridgeError(f"Invalid --set-env entry '{item}'. Expected KEY=VALUE.")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise BridgeError(f"Invalid --set-env entry '{item}'. Empty KEY.")
+        overrides[key] = value
+    return overrides
+
+
+def build_server_env(
+    spec_env: dict[str, str],
+    env_overrides: dict[str, str],
+    *,
+    runtime_mode: str | None,
+    runtime_profile: str | None,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(spec_env)
+
+    if runtime_mode:
+        env.setdefault("TG_SESSION_RUNTIME_MODE", runtime_mode)
+    if runtime_profile:
+        env.setdefault("TG_SESSION_RUNTIME_PROFILE", runtime_profile)
+
+    env.update(env_overrides)
+    return env
+
+
+def parse_args_payload(args_json: str | None, args_file: str | None) -> dict[str, Any]:
+    if args_json and args_file:
+        raise BridgeError("Use either --args-json or --args-file, not both.")
+
+    raw = "{}"
+    if args_json:
+        raw = args_json
+    elif args_file:
+        raw = Path(args_file).read_text(encoding="utf-8")
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise BridgeError(f"Invalid JSON arguments: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise BridgeError("Tool arguments must decode to a JSON object.")
+    return payload
+
+
+def extract_content_payload(result: dict[str, Any]) -> Any:
+    content = result.get("content")
+    if isinstance(content, list) and content:
+        item = content[0]
+        if isinstance(item, dict) and "text" in item:
+            text = str(item["text"])
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                return text
+    return result
+
+
+class MCPStdioClient:
+    def __init__(self, spec: ServerSpec, env: dict[str, str]):
+        self.spec = spec
+        self.env = env
+        self._proc: subprocess.Popen[str] | None = None
+        self._next_id = 1
+
+    def __enter__(self) -> "MCPStdioClient":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def start(self) -> None:
+        if self._proc is not None:
+            return
+        self._proc = subprocess.Popen(
+            [self.spec.command, *self.spec.args],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            cwd=self.spec.cwd,
+            env=self.env,
+        )
+        self._request(
+            "initialize",
+            {
+                "protocolVersion": DEFAULT_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "tg_action_bridge", "version": "0.1"},
+            },
+        )
+        self._notify("notifications/initialized", {})
+
+    def close(self) -> None:
+        if self._proc is None:
+            return
+        if self._proc.poll() is None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=2)
+        self._proc = None
+
+    def list_tools(self) -> list[str]:
+        result = self._request("tools/list", {})
+        tools = result.get("tools") or []
+        if not isinstance(tools, list):
+            raise BridgeError("Invalid tools/list payload from server.")
+        names = []
+        for item in tools:
+            if isinstance(item, dict) and item.get("name"):
+                names.append(str(item["name"]))
+        return names
+
+    def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+        result = self._request("tools/call", {"name": name, "arguments": arguments})
+        return extract_content_payload(result)
+
+    def _notify(self, method: str, params: dict[str, Any]) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def _request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        request_id = self._next_id
+        self._next_id += 1
+        self._send(
+            {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+        )
+        response = self._read_response()
+        if response.get("id") != request_id:
+            raise BridgeError(
+                f"Unexpected MCP response id={response.get('id')} for request {request_id}"
+            )
+        if "error" in response:
+            raise BridgeError(f"MCP error for {method}: {response['error']}")
+        result = response.get("result")
+        if not isinstance(result, dict):
+            raise BridgeError(f"Invalid MCP result for {method}: {response}")
+        return result
+
+    def _send(self, payload: dict[str, Any]) -> None:
+        if self._proc is None or self._proc.stdin is None:
+            raise BridgeError("MCP process is not running.")
+        self._proc.stdin.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        self._proc.stdin.flush()
+
+    def _read_response(self) -> dict[str, Any]:
+        if self._proc is None or self._proc.stdout is None:
+            raise BridgeError("MCP process is not running.")
+
+        while True:
+            line = self._proc.stdout.readline()
+            if line:
+                break
+            returncode = self._proc.poll()
+            stderr = ""
+            if self._proc.stderr is not None:
+                try:
+                    stderr = self._proc.stderr.read().strip()
+                except Exception:
+                    stderr = ""
+            if returncode is None:
+                raise BridgeError("No MCP response received.")
+            detail = f" (exit={returncode})" if returncode is not None else ""
+            if stderr:
+                detail += f" stderr={stderr}"
+            raise BridgeError(f"ActionMCP process exited before reply{detail}")
+
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise BridgeError(f"Invalid JSON-RPC line from server: {line!r}") from exc
+
+        if not isinstance(payload, dict):
+            raise BridgeError(f"Unexpected JSON-RPC payload: {payload!r}")
+        return payload
+
+
+def run_write_call(
+    client: MCPStdioClient,
+    *,
+    tool_name: str,
+    arguments: dict[str, Any],
+    confirmation_text: str,
+    approval_wait_sec: float,
+) -> dict[str, Any]:
+    preview_args = dict(arguments)
+    preview_args["dry_run"] = True
+    preview_args.pop("confirm", None)
+    preview_args.pop("approval_code", None)
+
+    preview = client.call_tool(tool_name, preview_args)
+    if not isinstance(preview, dict):
+        raise BridgeError(f"Expected JSON object from dry_run, got: {preview!r}")
+    if preview.get("success") is False:
+        return {"preview": preview, "execution": None}
+
+    approval_code = str(preview.get("approval_code") or "").strip()
+    if not approval_code:
+        raise BridgeError("Dry run did not return approval_code.")
+
+    if approval_wait_sec > 0:
+        time.sleep(approval_wait_sec)
+
+    execute_args = dict(arguments)
+    execute_args["dry_run"] = False
+    execute_args["confirm"] = True
+    execute_args["confirmation_text"] = confirmation_text
+    execute_args["approval_code"] = approval_code
+    execution = client.call_tool(tool_name, execute_args)
+    return {"preview": preview, "execution": execution}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config", default=str(DEFAULT_CONFIG_PATH), help="Path to Codex config.toml"
+    )
+    parser.add_argument(
+        "--server",
+        default=DEFAULT_SERVER_NAME,
+        help="ActionMCP server name in config.toml (underscore/hyphen aliases supported)",
+    )
+    parser.add_argument(
+        "--runtime-mode",
+        choices=("direct", "copy", "off"),
+        default=DEFAULT_RUNTIME_MODE,
+        help="Bridge-only TG_SESSION_RUNTIME_MODE override (default: copy)",
+    )
+    parser.add_argument(
+        "--runtime-profile",
+        default=DEFAULT_RUNTIME_PROFILE,
+        help="Bridge-only TG_SESSION_RUNTIME_PROFILE override (default: actions_bridge)",
+    )
+    parser.add_argument(
+        "--set-env",
+        action="append",
+        default=[],
+        help="Extra env override for spawned ActionMCP process (KEY=VALUE)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("tools", help="List available ActionMCP tool names")
+
+    call_parser = subparsers.add_parser(
+        "call", help="Call one ActionMCP tool with raw JSON args"
+    )
+    call_parser.add_argument(
+        "tool_name", help="Tool name, for example tg_get_actions_policy"
+    )
+    call_parser.add_argument("--args-json", help="Tool arguments as JSON object")
+    call_parser.add_argument(
+        "--args-file", help="Path to JSON file with tool arguments"
+    )
+
+    write_parser = subparsers.add_parser(
+        "write-call",
+        help="Run canonical dry_run -> approval_code -> confirm flow for write tools",
+    )
+    write_parser.add_argument(
+        "tool_name", help="Write tool name, for example tg_send_message"
+    )
+    write_parser.add_argument("--args-json", help="Tool arguments as JSON object")
+    write_parser.add_argument(
+        "--args-file", help="Path to JSON file with tool arguments"
+    )
+    write_parser.add_argument(
+        "--confirmation-text",
+        help="Exact confirmation_text to use; defaults to TG_ACTIONS_CONFIRMATION_PHRASE",
+    )
+    write_parser.add_argument(
+        "--approval-wait-sec",
+        default="auto",
+        help="Wait before execute: 'auto', '0', or explicit seconds",
+    )
+    return parser
+
+
+def resolve_approval_wait(raw_value: str, env: dict[str, str]) -> float:
+    value = (raw_value or "auto").strip().lower()
+    if value == "auto":
+        raw_env = str(env.get("TG_ACTIONS_APPROVAL_MIN_AGE_SEC", "0")).strip()
+        try:
+            return max(0.0, float(raw_env))
+        except ValueError:
+            return 0.0
+    try:
+        return max(0.0, float(value))
+    except ValueError as exc:
+        raise BridgeError(f"Invalid --approval-wait-sec value '{raw_value}'") from exc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        spec = load_server_spec(Path(args.config).expanduser().resolve(), args.server)
+        env_overrides = parse_env_overrides(args.set_env)
+        runtime_mode = None if args.runtime_mode == "off" else args.runtime_mode
+        runtime_profile = args.runtime_profile if runtime_mode else None
+        env = build_server_env(
+            spec.env,
+            env_overrides,
+            runtime_mode=runtime_mode,
+            runtime_profile=runtime_profile,
+        )
+
+        with MCPStdioClient(spec, env) as client:
+            if args.command == "tools":
+                payload = {"server": spec.name, "tools": client.list_tools()}
+            elif args.command == "call":
+                payload = client.call_tool(
+                    args.tool_name,
+                    parse_args_payload(
+                        getattr(args, "args_json", None),
+                        getattr(args, "args_file", None),
+                    ),
+                )
+            elif args.command == "write-call":
+                confirmation_text = (
+                    args.confirmation_text
+                    or str(
+                        env.get("TG_ACTIONS_CONFIRMATION_PHRASE", "отправляй")
+                    ).strip()
+                )
+                if not confirmation_text:
+                    raise BridgeError(
+                        "No confirmation text available. Set --confirmation-text or env."
+                    )
+                payload = run_write_call(
+                    client,
+                    tool_name=args.tool_name,
+                    arguments=parse_args_payload(args.args_json, args.args_file),
+                    confirmation_text=confirmation_text,
+                    approval_wait_sec=resolve_approval_wait(
+                        args.approval_wait_sec, env
+                    ),
+                )
+            else:
+                raise BridgeError(f"Unknown command: {args.command}")
+    except BridgeError as exc:
+        print(
+            json.dumps({"success": False, "error": str(exc)}, ensure_ascii=False),
+            file=sys.stderr,
+        )
+        return 2
+
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_group_creation_date.py
+++ b/tests/test_group_creation_date.py
@@ -1,14 +1,10 @@
-import pytest
-from unittest.mock import AsyncMock, MagicMock
 from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
 from tganalytics.domain.groups import GroupManager
-
-
-@pytest.fixture
-def mock_telegram_client():
-    """Мок Telegram клиента"""
-    client = AsyncMock()
-    return client
 
 
 @pytest.fixture
@@ -20,20 +16,23 @@ def mock_first_message():
 
 
 @pytest.mark.asyncio
-async def test_get_group_creation_date_with_id(mock_telegram_client, mock_first_message):
+async def test_get_group_creation_date_with_id(
+    mock_telegram_client, mock_channel, mock_first_message
+):
     """Тест получения даты создания группы по ID"""
-    
+    mock_telegram_client.get_entity.return_value = mock_channel
+
     # Создаем правильный async generator для iter_messages
     async def mock_iter_messages(*args, **kwargs):
         yield mock_first_message
-    
+
     mock_telegram_client.iter_messages = mock_iter_messages
-    
+
     group_manager = GroupManager(mock_telegram_client)
-    
+
     # Тестируем с числовым ID
     result = await group_manager.get_group_creation_date(-1002188344480)
-    
+
     assert result is not None
     assert result.year == 2024
     assert result.month == 7
@@ -41,72 +40,102 @@ async def test_get_group_creation_date_with_id(mock_telegram_client, mock_first_
 
 
 @pytest.mark.asyncio
-async def test_get_group_creation_date_with_string_id(mock_telegram_client, mock_first_message):
+async def test_get_group_creation_date_with_string_id(
+    mock_telegram_client, mock_channel, mock_first_message
+):
     """Тест получения даты создания группы по строковому ID"""
-    
+    mock_telegram_client.get_entity.return_value = mock_channel
+
     async def mock_iter_messages(*args, **kwargs):
         yield mock_first_message
-    
+
     mock_telegram_client.iter_messages = mock_iter_messages
-    
+
     group_manager = GroupManager(mock_telegram_client)
-    
+
     # Тестируем со строковым ID
     result = await group_manager.get_group_creation_date("-1002188344480")
-    
+
     assert result is not None
     assert result.year == 2024
 
 
 @pytest.mark.asyncio
-async def test_get_group_creation_date_with_username(mock_telegram_client, mock_first_message):
+async def test_get_group_creation_date_with_username(
+    mock_telegram_client, mock_channel, mock_first_message
+):
     """Тест получения даты создания группы по username"""
-    
+    mock_telegram_client.get_entity.return_value = mock_channel
+
     async def mock_iter_messages(*args, **kwargs):
         yield mock_first_message
-    
+
     mock_telegram_client.iter_messages = mock_iter_messages
-    
+
     group_manager = GroupManager(mock_telegram_client)
-    
+
     # Тестируем с username без @
     result = await group_manager.get_group_creation_date("testgroup")
-    
+
     assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_get_group_creation_date_resolves_dialog_title_with_spaces(
+    mock_telegram_client, mock_channel, mock_first_message
+):
+    """Title с пробелами должен работать и для даты создания."""
+    from tests.conftest import AsyncIteratorMock
+
+    mock_channel.title = "attia project"
+    mock_telegram_client.iter_dialogs = MagicMock(
+        return_value=AsyncIteratorMock([SimpleNamespace(entity=mock_channel)])
+    )
+
+    async def mock_iter_messages(*args, **kwargs):
+        yield mock_first_message
+
+    mock_telegram_client.iter_messages = mock_iter_messages
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.get_group_creation_date("attia project")
+
+    assert result is not None
+    assert result.year == 2024
 
 
 @pytest.mark.asyncio
 async def test_get_group_creation_date_no_messages(mock_telegram_client):
     """Тест случая когда в группе нет сообщений"""
-    
+
     async def mock_iter_messages(*args, **kwargs):
         # Пустой async generator
         if False:
             yield  # недостижимый код для создания async generator
-    
+
     mock_telegram_client.iter_messages = mock_iter_messages
-    
+
     group_manager = GroupManager(mock_telegram_client)
-    
+
     result = await group_manager.get_group_creation_date(-1002188344480)
-    
+
     assert result is None
 
 
 @pytest.mark.asyncio
 async def test_get_group_creation_date_error(mock_telegram_client):
     """Тест обработки ошибок при получении даты создания"""
-    
+
     # Настраиваем мок для выброса исключения
     async def mock_iter_messages_error(*args, **kwargs):
         if False:
             yield None
         raise Exception("Connection error")
-    
+
     mock_telegram_client.iter_messages = mock_iter_messages_error
-    
+
     group_manager = GroupManager(mock_telegram_client)
-    
+
     result = await group_manager.get_group_creation_date(-1002188344480)
-    
+
     assert result is None

--- a/tests/test_group_manager.py
+++ b/tests/test_group_manager.py
@@ -2,61 +2,73 @@
 Тесты для GroupManager
 """
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 from telethon.errors import ChatAdminRequiredError, FloodWaitError
-from telethon.errors.rpcerrorlist import UserAlreadyParticipantError, UserNotParticipantError
+from telethon.errors.rpcerrorlist import (
+    UserAlreadyParticipantError,
+    UserNotParticipantError,
+)
+from telethon.tl.types import Channel, Chat, User
+
+import tganalytics.domain.groups as groups_module
 from tganalytics.domain.groups import GroupManager
-from telethon.tl.types import User
+
 
 @pytest.mark.asyncio
 async def test_get_group_info_success(mock_telegram_client, mock_channel):
     """Тест успешного получения информации о группе"""
     # Настройка мока
     mock_telegram_client.get_entity.return_value = mock_channel
-    
+
     # Создание менеджера
     group_manager = GroupManager(mock_telegram_client)
-    
+
     # Выполнение теста
     result = await group_manager.get_group_info("testgroup")
-    
+
     # Проверки
     assert result is not None
-    assert result['id'] == mock_channel.id
-    assert result['title'] == mock_channel.title
-    assert result['username'] == mock_channel.username
-    assert result['participants_count'] == mock_channel.participants_count
-    assert result['type'] == 'channel'
-    
+    assert result["id"] == mock_channel.id
+    assert result["title"] == mock_channel.title
+    assert result["username"] == mock_channel.username
+    assert result["participants_count"] == mock_channel.participants_count
+    assert result["type"] == "channel"
+
     # Проверка вызова
-    mock_telegram_client.get_entity.assert_called_once_with('@testgroup')
+    mock_telegram_client.get_entity.assert_called_once_with("@testgroup")
+
 
 @pytest.mark.asyncio
 async def test_get_group_info_without_at_prefix(mock_telegram_client, mock_channel):
     """Тест получения информации о группе без @ префикса"""
     mock_telegram_client.get_entity.return_value = mock_channel
-    
+
     group_manager = GroupManager(mock_telegram_client)
     result = await group_manager.get_group_info("testgroup")
-    
+
     assert result is not None
-    mock_telegram_client.get_entity.assert_called_once_with('@testgroup')
+    mock_telegram_client.get_entity.assert_called_once_with("@testgroup")
+
 
 @pytest.mark.asyncio
 async def test_get_group_info_not_found(mock_telegram_client):
     """Тест обработки случая, когда группа не найдена"""
     mock_telegram_client.get_entity.side_effect = Exception("Group not found")
-    
+
     group_manager = GroupManager(mock_telegram_client)
     result = await group_manager.get_group_info("nonexistent")
-    
+
     assert result is None
 
 
 @pytest.mark.asyncio
-async def test_get_group_info_resolves_dialog_title_with_spaces(mock_telegram_client, mock_channel):
+async def test_get_group_info_resolves_dialog_title_with_spaces(
+    mock_telegram_client, mock_channel
+):
     """Тест fallback на title диалога, если передали имя группы с пробелами."""
     from tests.conftest import AsyncIteratorMock
 
@@ -72,151 +84,397 @@ async def test_get_group_info_resolves_dialog_title_with_spaces(mock_telegram_cl
     assert result["id"] == mock_channel.id
     assert result["title"] == "attia project"
 
+
 @pytest.mark.asyncio
-async def test_get_participants_success(mock_telegram_client, mock_channel, mock_participants_iterator):
+async def test_get_group_info_supports_direct_user_dialog(
+    mock_telegram_client, mock_user
+):
+    """Direct dialog info должен возвращаться и для user target."""
+    mock_telegram_client.get_entity.return_value = mock_user
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.get_group_info("test_user")
+
+    assert result is not None
+    assert result["id"] == mock_user.id
+    assert result["type"] == "user"
+    assert result["title"] == "Test User"
+    assert result["username"] == "test_user"
+
+
+@pytest.mark.asyncio
+async def test_get_group_info_resolves_direct_user_dialog_title(
+    mock_telegram_client, mock_user
+):
+    """Title-based lookup должен находить и 1:1 dialogs."""
+    from tests.conftest import AsyncIteratorMock
+
+    mock_telegram_client.iter_dialogs.return_value = AsyncIteratorMock(
+        [SimpleNamespace(entity=mock_user, title="Test User", name="Test User")]
+    )
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.get_group_info("Test User")
+
+    assert result is not None
+    assert result["id"] == mock_user.id
+    assert result["type"] == "user"
+    assert result["title"] == "Test User"
+
+
+@pytest.mark.asyncio
+async def test_get_participants_success(
+    mock_telegram_client, mock_channel, mock_participants_iterator
+):
     """Тест успешного получения участников группы"""
     # Настройка моков
     mock_telegram_client.get_entity.return_value = mock_channel
     mock_telegram_client.iter_participants.return_value = mock_participants_iterator
-    
+
     group_manager = GroupManager(mock_telegram_client)
     participants = await group_manager.get_participants("testgroup", limit=10)
-    
+
     assert len(participants) == 1
-    assert participants[0]['id'] == 123456789
-    assert participants[0]['username'] == "test_user"
-    assert participants[0]['first_name'] == "Test"
-    assert participants[0]['is_bot'] == False
+    assert participants[0]["id"] == 123456789
+    assert participants[0]["username"] == "test_user"
+    assert participants[0]["first_name"] == "Test"
+    assert participants[0]["is_bot"] is False
+
 
 @pytest.mark.asyncio
-async def test_get_participants_exclude_bots(mock_telegram_client, mock_channel, mock_bot_and_user_iterator):
+async def test_get_participants_resolves_dialog_title_with_spaces(
+    mock_telegram_client, mock_channel, mock_participants_iterator
+):
+    """Title с пробелами должен работать и для participants."""
+    from tests.conftest import AsyncIteratorMock
+
+    mock_channel.title = "attia project"
+    mock_telegram_client.iter_dialogs.return_value = AsyncIteratorMock(
+        [SimpleNamespace(entity=mock_channel)]
+    )
+    mock_telegram_client.iter_participants.return_value = mock_participants_iterator
+
+    group_manager = GroupManager(mock_telegram_client)
+    participants = await group_manager.get_participants("attia project", limit=10)
+
+    assert len(participants) == 1
+    mock_telegram_client.iter_participants.assert_called_once_with(
+        mock_channel, limit=10
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_participants_exclude_bots(
+    mock_telegram_client, mock_channel, mock_bot_and_user_iterator
+):
     """Тест исключения ботов из списка участников"""
     # Настройка моков
     mock_telegram_client.get_entity.return_value = mock_channel
     mock_telegram_client.iter_participants.return_value = mock_bot_and_user_iterator
-    
+
     group_manager = GroupManager(mock_telegram_client)
     participants = await group_manager.get_participants("testgroup", limit=10)
-    
+
     # Должен быть только обычный пользователь, бот исключен
     assert len(participants) == 1
-    assert participants[0]['username'] == "regular_user"
-    assert participants[0]['is_bot'] == False
+    assert participants[0]["username"] == "regular_user"
+    assert participants[0]["is_bot"] is False
+
 
 @pytest.mark.asyncio
-async def test_get_participants_admin_required_error(mock_telegram_client, mock_channel):
+async def test_get_participants_admin_required_error(
+    mock_telegram_client, mock_channel
+):
     """Тест обработки ошибки отсутствия прав администратора"""
     mock_telegram_client.get_entity.return_value = mock_channel
-    mock_telegram_client.iter_participants.side_effect = ChatAdminRequiredError("No admin rights")
-    
+    mock_telegram_client.iter_participants.side_effect = ChatAdminRequiredError(
+        "No admin rights"
+    )
+
     group_manager = GroupManager(mock_telegram_client)
     participants = await group_manager.get_participants("testgroup")
-    
+
     assert participants == []
+
 
 @pytest.mark.asyncio
 async def test_get_participants_flood_wait_error(mock_telegram_client, mock_channel):
     """Тест обработки ошибки превышения лимита запросов"""
     mock_telegram_client.get_entity.return_value = mock_channel
     mock_telegram_client.iter_participants.side_effect = FloodWaitError(60)
-    
+
     group_manager = GroupManager(mock_telegram_client)
     participants = await group_manager.get_participants("testgroup")
-    
+
     assert participants == []
 
+
 @pytest.mark.asyncio
-async def test_search_participants_success(mock_telegram_client, mock_participants_iterator):
+async def test_search_participants_success(
+    mock_telegram_client, mock_channel, mock_participants_iterator
+):
     """Тест успешного поиска участников"""
+    mock_telegram_client.get_entity.return_value = mock_channel
     mock_telegram_client.iter_participants.return_value = mock_participants_iterator
-    
+
     group_manager = GroupManager(mock_telegram_client)
-    participants = await group_manager.search_participants("testgroup", "test", limit=10)
-    
-    assert len(participants) == 1
-    assert participants[0]['username'] == "test_user"
-    
-    # Проверяем, что поиск вызван с правильными параметрами (с добавленным @)
-    mock_telegram_client.iter_participants.assert_called_once_with(
-        "@testgroup", search="test", limit=10
+    participants = await group_manager.search_participants(
+        "testgroup", "test", limit=10
     )
+
+    assert len(participants) == 1
+    assert participants[0]["username"] == "test_user"
+
+    # Проверяем, что поиск вызван с entity, а не сырым username.
+    mock_telegram_client.iter_participants.assert_called_once_with(
+        mock_channel, search="test", limit=10
+    )
+
 
 @pytest.mark.asyncio
 async def test_search_participants_empty_result(mock_telegram_client):
     """Тест поиска участников с пустым результатом"""
     from tests.conftest import AsyncIteratorMock
+
     mock_telegram_client.iter_participants.return_value = AsyncIteratorMock([])
-    
+
     group_manager = GroupManager(mock_telegram_client)
     participants = await group_manager.search_participants("testgroup", "nonexistent")
-    
+
     assert participants == []
 
+
 @pytest.mark.asyncio
-async def test_export_participants_to_csv_success(mock_telegram_client, mock_channel, sample_participants, tmp_path):
+async def test_search_participants_resolves_dialog_title_with_spaces(
+    mock_telegram_client, mock_channel, mock_participants_iterator
+):
+    """Title с пробелами должен работать и для search."""
+    from tests.conftest import AsyncIteratorMock
+
+    mock_channel.title = "attia project"
+    mock_telegram_client.iter_dialogs.return_value = AsyncIteratorMock(
+        [SimpleNamespace(entity=mock_channel)]
+    )
+    mock_telegram_client.iter_participants.return_value = mock_participants_iterator
+
+    group_manager = GroupManager(mock_telegram_client)
+    participants = await group_manager.search_participants(
+        "attia project", "test", limit=10
+    )
+
+    assert len(participants) == 1
+    mock_telegram_client.iter_participants.assert_called_once_with(
+        mock_channel, search="test", limit=10
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_participants_to_csv_success(
+    mock_telegram_client, mock_channel, sample_participants, tmp_path
+):
     """Тест успешного экспорта участников в CSV"""
     # Создаем моки пользователей из sample_participants
     from tests.conftest import AsyncIteratorMock
-    
+
     mock_users = []
     for participant in sample_participants:
         user = MagicMock(spec=User)
-        user.id = participant['id']
-        user.username = participant['username']
-        user.first_name = participant['first_name']
-        user.last_name = participant['last_name']
-        user.phone = participant['phone']
-        user.bot = participant['is_bot']
-        user.verified = participant['is_verified']
-        user.premium = participant['is_premium']
-        user.status = participant['status']
+        user.id = participant["id"]
+        user.username = participant["username"]
+        user.first_name = participant["first_name"]
+        user.last_name = participant["last_name"]
+        user.phone = participant["phone"]
+        user.bot = participant["is_bot"]
+        user.verified = participant["is_verified"]
+        user.premium = participant["is_premium"]
+        user.status = participant["status"]
         mock_users.append(user)
-    
+
     # Настройка моков
     mock_telegram_client.get_entity.return_value = mock_channel
     mock_telegram_client.iter_participants.return_value = AsyncIteratorMock(mock_users)
-    
+
     group_manager = GroupManager(mock_telegram_client)
-    
+
     # Создаем временный файл
     csv_file = tmp_path / "test_participants.csv"
-    
+
     # Выполняем экспорт
-    result = await group_manager.export_participants_to_csv("testgroup", str(csv_file), limit=10)
-    
-    assert result == True
+    result = await group_manager.export_participants_to_csv(
+        "testgroup", str(csv_file), limit=10
+    )
+
+    assert result is True
     assert csv_file.exists()
-    
+
     # Проверяем содержимое файла
-    content = csv_file.read_text(encoding='utf-8')
-    assert "id,username,first_name,last_name,phone,is_verified,is_premium,status" in content
+    content = csv_file.read_text(encoding="utf-8")
+    assert (
+        "id,username,first_name,last_name,phone,is_verified,is_premium,status"
+        in content
+    )
     assert "user1" in content
     assert "user2" in content
 
+
 @pytest.mark.asyncio
-async def test_export_participants_to_csv_no_participants(mock_telegram_client, mock_channel, tmp_path):
+async def test_export_participants_to_csv_no_participants(
+    mock_telegram_client, mock_channel, tmp_path
+):
     """Тест экспорта при отсутствии участников"""
     from tests.conftest import AsyncIteratorMock
-    
+
     mock_telegram_client.get_entity.return_value = mock_channel
     mock_telegram_client.iter_participants.return_value = AsyncIteratorMock([])
-    
+
     group_manager = GroupManager(mock_telegram_client)
     csv_file = tmp_path / "empty_participants.csv"
-    
+
     result = await group_manager.export_participants_to_csv("testgroup", str(csv_file))
-    
-    assert result == False
+
+    assert result is False
     assert not csv_file.exists()
 
 
 @pytest.mark.asyncio
-async def test_add_member_to_group_dry_run(mock_telegram_client, mock_channel, mock_user):
+async def test_get_message_count_supports_direct_user_dialog(
+    mock_telegram_client, mock_user
+):
+    """Direct dialog count не должен отбрасываться из-за User entity."""
+    mock_telegram_client.get_entity.return_value = mock_user
+    mock_telegram_client.return_value = SimpleNamespace(count=42)
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.get_message_count("test_user")
+
+    assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_get_messages_supports_direct_user_dialog(
+    mock_telegram_client, mock_user
+):
+    """Direct dialog history должен читаться тем же get_messages path."""
+    from tests.conftest import AsyncIteratorMock
+
+    mock_telegram_client.get_entity.return_value = mock_user
+    mock_telegram_client.iter_messages.return_value = AsyncIteratorMock(
+        [
+            SimpleNamespace(
+                id=1,
+                date=datetime(2026, 4, 2, 10, 30, 0),
+                from_id=SimpleNamespace(user_id=mock_user.id),
+                message="hello",
+                media=None,
+                fwd_from=None,
+                forward=None,
+                reply_to=None,
+                views=None,
+                forwards=None,
+                is_pinned=False,
+            )
+        ]
+    )
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.get_messages("test_user", limit=10)
+
+    assert len(result) == 1
+    assert result[0]["id"] == 1
+    assert result[0]["text"] == "hello"
+    mock_telegram_client.iter_messages.assert_called_once_with(
+        mock_user,
+        limit=10,
+        min_id=0,
+        reverse=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_messages_since_stops_at_cutoff(mock_telegram_client, mock_user):
+    """Since-export читает newest->oldest и останавливается на cutoff."""
+    from tests.conftest import AsyncIteratorMock
+
+    mock_telegram_client.get_entity.return_value = mock_user
+    mock_telegram_client.iter_messages.return_value = AsyncIteratorMock(
+        [
+            SimpleNamespace(
+                id=3,
+                date=datetime(2026, 4, 2, 10, 30, 0),
+                from_id=SimpleNamespace(user_id=mock_user.id),
+                message="recent message",
+                media=None,
+                fwd_from=None,
+                forward=None,
+                reply_to=None,
+                views=None,
+                forwards=None,
+                is_pinned=False,
+                file=None,
+            ),
+            SimpleNamespace(
+                id=2,
+                date=datetime(2020, 12, 31, 23, 59, 0),
+                from_id=SimpleNamespace(user_id=mock_user.id),
+                message="old",
+                media=None,
+                fwd_from=None,
+                forward=None,
+                reply_to=None,
+                views=None,
+                forwards=None,
+                is_pinned=False,
+                file=None,
+            ),
+        ]
+    )
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.get_messages_since("test_user", "2021-01-01")
+
+    assert len(result) == 1
+    assert result[0]["id"] == 3
+
+
+@pytest.mark.asyncio
+async def test_leave_dialog_dry_run_channel(mock_telegram_client, mock_channel):
+    """Dry-run leave должен резолвить канал и не делать write request."""
+    mock_channel.broadcast = True
+    mock_telegram_client.get_entity.return_value = mock_channel
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.leave_dialog("testgroup", dry_run=True)
+
+    assert result["success"] is True
+    assert result["dry_run"] is True
+    assert result["action"] == "leave_dialog"
+    assert result["dialog_type"] == "channel"
+    assert mock_telegram_client.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_leave_dialog_blocks_direct_user(mock_telegram_client, mock_user):
+    """Direct user dialogs cannot be left through channel leave action."""
+    mock_telegram_client.get_entity.return_value = mock_user
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.leave_dialog("test_user", dry_run=True)
+
+    assert result["success"] is False
+    assert "Direct user dialogs" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_add_member_to_group_dry_run(
+    mock_telegram_client, mock_channel, mock_user
+):
     """Dry-run добавления участника не должен делать write-операцию."""
     mock_telegram_client.get_entity.side_effect = [mock_channel, mock_user]
 
     group_manager = GroupManager(mock_telegram_client)
-    result = await group_manager.add_member_to_group("testgroup", "test_user", dry_run=True)
+    result = await group_manager.add_member_to_group(
+        "testgroup", "test_user", dry_run=True
+    )
 
     assert result["success"] is True
     assert result["dry_run"] is True
@@ -225,26 +483,189 @@ async def test_add_member_to_group_dry_run(mock_telegram_client, mock_channel, m
 
 
 @pytest.mark.asyncio
-async def test_add_member_to_group_already_member(mock_telegram_client, mock_channel, mock_user):
+async def test_set_channel_comments_join_requirement_dry_run(
+    mock_telegram_client, mock_channel
+):
+    """Dry-run должен находить linked discussion group и не делать write."""
+    linked_group = MagicMock(spec=Channel)
+    linked_group.id = 5023804528
+    linked_group.title = "Matskevich comments"
+    linked_group.username = "matskevich_chat"
+    linked_group.join_to_send = True
+
+    mock_telegram_client.get_entity.return_value = mock_channel
+    mock_telegram_client.side_effect = [
+        SimpleNamespace(
+            full_chat=SimpleNamespace(linked_chat_id=linked_group.id),
+            chats=[linked_group],
+        )
+    ]
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.set_channel_comments_join_requirement(
+        "testgroup",
+        join_required=False,
+        dry_run=True,
+    )
+
+    assert result["success"] is True
+    assert result["dry_run"] is True
+    assert result["linked_group_id"] == linked_group.id
+    assert result["linked_group_target"] == "@matskevich_chat"
+    assert result["current_join_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_private_group_dry_run_resolves_invitees(
+    mock_telegram_client, mock_user
+):
+    """Dry-run создания группы резолвит invitees и не делает write."""
+    mock_telegram_client.get_entity.return_value = mock_user
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.create_private_group(
+        "email critical",
+        users=["@hermess260408bot"],
+        dry_run=True,
+    )
+
+    assert result["success"] is True
+    assert result["dry_run"] is True
+    assert result["title"] == "email critical"
+    assert result["invitees"][0]["username"] == "test_user"
+    assert mock_telegram_client.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_create_private_group_executes_create_and_invite(
+    mock_telegram_client, mock_user
+):
+    """Execute path создает basic private group с initial invitee."""
+    mock_chat = MagicMock(spec=Chat)
+    mock_chat.id = -4697000000
+    mock_chat.title = "email critical"
+    mock_chat.participants_count = 2
+    mock_telegram_client.get_entity.return_value = mock_user
+    mock_telegram_client.side_effect = [
+        SimpleNamespace(chats=[mock_chat]),
+    ]
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.create_private_group(
+        "email critical",
+        users=["@hermess260408bot"],
+        dry_run=False,
+    )
+
+    assert result["success"] is True
+    assert result["dry_run"] is False
+    assert result["group_id"] == mock_chat.id
+    assert result["invites"][0]["success"] is True
+    assert result["invites"][0]["created_with_group"] is True
+    assert mock_telegram_client.await_count == 1
+    create_request = mock_telegram_client.await_args_list[0].args[0]
+    assert type(create_request).__name__ == "CreateChatRequest"
+    assert create_request.title == "email critical"
+
+
+@pytest.mark.asyncio
+async def test_create_private_group_falls_back_to_dialog_title(
+    mock_telegram_client, mock_user
+):
+    """Если Telegram Updates не содержит chat entity, ищем созданную группу по title."""
+    from tests.conftest import AsyncIteratorMock
+
+    mock_chat = MagicMock(spec=Chat)
+    mock_chat.id = -4697000000
+    mock_chat.title = "email critical"
+    mock_chat.participants_count = 2
+    mock_telegram_client.get_entity.return_value = mock_user
+    mock_telegram_client.side_effect = [
+        SimpleNamespace(chats=[]),
+    ]
+    mock_telegram_client.iter_dialogs.return_value = AsyncIteratorMock(
+        [
+            SimpleNamespace(
+                entity=mock_chat, title="email critical", name="email critical"
+            )
+        ]
+    )
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.create_private_group(
+        "email critical",
+        users=["@hermess260408bot"],
+        dry_run=False,
+    )
+
+    assert result["success"] is True
+    assert result["group_id"] == mock_chat.id
+
+
+@pytest.mark.asyncio
+async def test_set_channel_comments_join_requirement_executes_toggle(
+    mock_telegram_client, mock_channel
+):
+    """Execute path должен дернуть ToggleJoinToSendRequest для linked group."""
+    linked_group = MagicMock(spec=Channel)
+    linked_group.id = 5023804528
+    linked_group.title = "Matskevich comments"
+    linked_group.username = None
+    linked_group.join_to_send = True
+
+    mock_telegram_client.get_entity.return_value = mock_channel
+    mock_telegram_client.side_effect = [
+        SimpleNamespace(
+            full_chat=SimpleNamespace(linked_chat_id=linked_group.id),
+            chats=[linked_group],
+        ),
+        MagicMock(),
+    ]
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.set_channel_comments_join_requirement(
+        "testgroup",
+        join_required=False,
+        dry_run=False,
+    )
+
+    assert result["success"] is True
+    assert result["current_join_required"] is False
+    assert mock_telegram_client.await_count == 2
+    toggle_request = mock_telegram_client.await_args_list[1].args[0]
+    assert type(toggle_request).__name__ == "ToggleJoinToSendRequest"
+    assert toggle_request.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_add_member_to_group_already_member(
+    mock_telegram_client, mock_channel, mock_user
+):
     """Если пользователь уже в группе, операция считается идемпотентно успешной."""
     mock_telegram_client.get_entity.side_effect = [mock_channel, mock_user]
     mock_telegram_client.side_effect = UserAlreadyParticipantError(request=None)
 
     group_manager = GroupManager(mock_telegram_client)
-    result = await group_manager.add_member_to_group("testgroup", "test_user", dry_run=False)
+    result = await group_manager.add_member_to_group(
+        "testgroup", "test_user", dry_run=False
+    )
 
     assert result["success"] is True
     assert result["already_member"] is True
 
 
 @pytest.mark.asyncio
-async def test_remove_member_from_group_not_participant(mock_telegram_client, mock_channel, mock_user):
+async def test_remove_member_from_group_not_participant(
+    mock_telegram_client, mock_channel, mock_user
+):
     """Если пользователя нет в группе, remove считается идемпотентно успешным."""
     mock_telegram_client.get_entity.side_effect = [mock_channel, mock_user]
     mock_telegram_client.side_effect = UserNotParticipantError(request=None)
 
     group_manager = GroupManager(mock_telegram_client)
-    result = await group_manager.remove_member_from_group("testgroup", "test_user", dry_run=False)
+    result = await group_manager.remove_member_from_group(
+        "testgroup", "test_user", dry_run=False
+    )
 
     assert result["success"] is True
     assert result["not_participant"] is True
@@ -254,8 +675,10 @@ async def test_remove_member_from_group_not_participant(mock_telegram_client, mo
 async def test_migrate_member_dry_run(mock_telegram_client, mock_channel, mock_user):
     """Dry-run миграции возвращает план add/remove без изменений в Telegram."""
     mock_telegram_client.get_entity.side_effect = [
-        mock_channel, mock_user,  # add preview
-        mock_channel, mock_user,  # remove preview
+        mock_channel,
+        mock_user,  # add preview
+        mock_channel,
+        mock_user,  # remove preview
     ]
 
     group_manager = GroupManager(mock_telegram_client)
@@ -271,6 +694,30 @@ async def test_migrate_member_dry_run(mock_telegram_client, mock_channel, mock_u
     assert result["action"] == "migrate_member"
     assert result["add_new_user"]["action"] == "add_member"
     assert result["remove_old_user"]["action"] == "remove_member"
+
+
+@pytest.mark.asyncio
+async def test_delete_messages_uses_api_quota_not_group_message(
+    monkeypatch, mock_telegram_client, mock_channel
+):
+    """delete_messages is destructive, but it must not consume send-message quota."""
+    mock_telegram_client.get_entity.return_value = mock_channel
+    calls = []
+
+    async def fake_safe_api_call(func, *args, **kwargs):
+        calls.append(kwargs.get("operation_type"))
+        return True
+
+    monkeypatch.setattr(groups_module, "_safe_api_call", fake_safe_api_call)
+
+    group_manager = GroupManager(mock_telegram_client)
+    result = await group_manager.delete_messages(
+        str(mock_channel.id), [1, 2], dry_run=False
+    )
+
+    assert result["success"] is True
+    assert "group_msg" not in calls
+    assert calls[-1] == "api"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_actions_confirmation.py
+++ b/tests/test_mcp_actions_confirmation.py
@@ -1,11 +1,110 @@
-import pytest
-
 import mcp_server_actions as actions
+import pytest
 
 
 class _FakeManager:
+    async def create_private_group(
+        self, title, users=None, about="", kind="basic", dry_run=False
+    ):
+        return {
+            "success": True,
+            "action": "create_private_group",
+            "dry_run": dry_run,
+            "title": title,
+            "about": about,
+            "kind": kind,
+            "invitees": [
+                {
+                    "input": user,
+                    "user_id": 1000 + index,
+                    "username": str(user).lstrip("@"),
+                }
+                for index, user in enumerate(users or [])
+            ],
+            "group_id": 123456789 if not dry_run else None,
+        }
+
     async def send_message(self, group, message_text):
         return True
+
+    async def delete_messages(self, group, message_ids, revoke=True, dry_run=False):
+        return {
+            "success": True,
+            "action": "delete_messages",
+            "dry_run": dry_run,
+            "target": group,
+            "message_ids": list(message_ids),
+            "message_count": len(message_ids),
+            "revoke": revoke,
+        }
+
+    async def clear_history(
+        self, group, max_id=0, revoke=True, just_clear=False, dry_run=False
+    ):
+        return {
+            "success": True,
+            "action": "clear_history",
+            "dry_run": dry_run,
+            "target": group,
+            "max_id": max_id,
+            "revoke": revoke,
+            "just_clear": just_clear,
+        }
+
+    async def leave_dialog(self, group, dry_run=False):
+        return {
+            "success": True,
+            "action": "leave_dialog",
+            "dry_run": dry_run,
+            "target": group,
+            "dialog_type": "channel",
+        }
+
+    async def edit_message(self, group, message_id, new_text, dry_run=False):
+        return {
+            "success": True,
+            "action": "edit_message",
+            "dry_run": dry_run,
+            "target": group,
+            "message_id": message_id,
+            "new_text_len": len(new_text),
+        }
+
+    async def forward_messages(
+        self,
+        from_group,
+        to_group,
+        message_ids,
+        drop_author=False,
+        drop_media_captions=False,
+        dry_run=False,
+    ):
+        return {
+            "success": True,
+            "action": "forward_messages",
+            "dry_run": dry_run,
+            "from_target": from_group,
+            "to_target": to_group,
+            "message_ids": list(message_ids),
+            "message_count": len(message_ids),
+            "drop_author": drop_author,
+            "drop_media_captions": drop_media_captions,
+        }
+
+    async def set_channel_comments_join_requirement(
+        self, channel_identifier, join_required, dry_run=False
+    ):
+        return {
+            "success": True,
+            "action": "set_channel_comments_join_requirement",
+            "dry_run": dry_run,
+            "join_required": join_required,
+            "channel_target": "@Matskevich",
+            "linked_group_target": "@matskevich_chat",
+            "linked_group_id": 5023804528,
+            "linked_group_title": "Matskevich comments",
+            "current_join_required": True if dry_run else join_required,
+        }
 
 
 class _FakeCtx:
@@ -37,6 +136,65 @@ async def test_send_message_requires_exact_confirmation_text(monkeypatch, tmp_pa
 
     assert result["success"] is False
     assert "confirmation_text" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_private_group_requires_allowlisted_title(monkeypatch, tmp_path):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
+    monkeypatch.setattr(actions, "ALLOWED_TARGETS", {"other_target"})
+    monkeypatch.setattr(actions, "REQUIRE_CONFIRMATION_TEXT", True)
+    monkeypatch.setattr(actions, "CONFIRMATION_PHRASE", "отправляй")
+    monkeypatch.setattr(actions, "REQUIRE_APPROVAL_CODE", True)
+    monkeypatch.setattr(actions, "APPROVAL_FILE", tmp_path / "approvals.json")
+
+    result = await actions.tg_create_private_group(
+        title="email critical",
+        users=["@hermess260408bot"],
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert "TG_ACTIONS_ALLOWED_GROUPS" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_private_group_runs_dry_run_then_confirm(monkeypatch, tmp_path):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
+    monkeypatch.setattr(actions, "ALLOWED_TARGETS", {"email critical"})
+    monkeypatch.setattr(actions, "REQUIRE_CONFIRMATION_TEXT", True)
+    monkeypatch.setattr(actions, "CONFIRMATION_PHRASE", "отправляй")
+    monkeypatch.setattr(actions, "REQUIRE_APPROVAL_CODE", True)
+    monkeypatch.setattr(actions, "IDEMPOTENCY_ENABLED", False)
+    monkeypatch.setattr(actions, "APPROVAL_TTL_SEC", 1800)
+    monkeypatch.setattr(actions, "APPROVAL_MIN_AGE_SEC", 0)
+    monkeypatch.setattr(actions, "APPROVAL_FILE", tmp_path / "approvals.json")
+    monkeypatch.setattr(actions, "ctx", _FakeCtx())
+
+    preview = await actions.tg_create_private_group(
+        title="email critical",
+        users=["@hermess260408bot"],
+        dry_run=True,
+    )
+    assert preview["success"] is True
+    approval_code = preview.get("approval_code")
+    assert approval_code
+
+    created = await actions.tg_create_private_group(
+        title="email critical",
+        users=["@hermess260408bot"],
+        dry_run=False,
+        confirm=True,
+        confirmation_text="отправляй",
+        approval_code=approval_code,
+    )
+
+    assert created["success"] is True
+    assert created["group_id"] == 123456789
+    assert created["invitees"][0]["input"] == "@hermess260408bot"
 
 
 @pytest.mark.asyncio
@@ -97,7 +255,9 @@ async def test_send_message_requires_one_time_approval_code(monkeypatch, tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_send_message_blocks_immediate_execute_after_dry_run(monkeypatch, tmp_path):
+async def test_send_message_blocks_immediate_execute_after_dry_run(
+    monkeypatch, tmp_path
+):
     monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
     monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
     monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
@@ -146,3 +306,164 @@ async def test_send_message_blocks_immediate_execute_after_dry_run(monkeypatch, 
         approval_code=approval_code,
     )
     assert sent["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_channel_comments_join_requirement_requires_allowlisted_linked_group(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
+    monkeypatch.setattr(actions, "ALLOWED_TARGETS", {"other_target"})
+    monkeypatch.setattr(actions, "REQUIRE_CONFIRMATION_TEXT", True)
+    monkeypatch.setattr(actions, "CONFIRMATION_PHRASE", "отправляй")
+    monkeypatch.setattr(actions, "REQUIRE_APPROVAL_CODE", True)
+    monkeypatch.setattr(actions, "IDEMPOTENCY_ENABLED", False)
+    monkeypatch.setattr(actions, "APPROVAL_FILE", tmp_path / "approvals.json")
+    monkeypatch.setattr(actions, "ctx", _FakeCtx())
+
+    result = await actions.tg_set_channel_comments_join_requirement(
+        channel="@Matskevich",
+        join_required=False,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert result["linked_group_target"] == "@matskevich_chat"
+    assert "not in TG_ACTIONS_ALLOWED_GROUPS" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_set_channel_comments_join_requirement_executes_after_dry_run(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
+    monkeypatch.setattr(actions, "ALLOWED_TARGETS", {"matskevich_chat"})
+    monkeypatch.setattr(actions, "REQUIRE_CONFIRMATION_TEXT", True)
+    monkeypatch.setattr(actions, "CONFIRMATION_PHRASE", "отправляй")
+    monkeypatch.setattr(actions, "REQUIRE_APPROVAL_CODE", True)
+    monkeypatch.setattr(actions, "IDEMPOTENCY_ENABLED", False)
+    monkeypatch.setattr(actions, "APPROVAL_TTL_SEC", 1800)
+    monkeypatch.setattr(actions, "APPROVAL_MIN_AGE_SEC", 0)
+    monkeypatch.setattr(actions, "APPROVAL_FILE", tmp_path / "approvals.json")
+    monkeypatch.setattr(actions, "ctx", _FakeCtx())
+
+    preview = await actions.tg_set_channel_comments_join_requirement(
+        channel="@Matskevich",
+        join_required=False,
+        dry_run=True,
+    )
+    assert preview["success"] is True
+    approval_code = preview.get("approval_code")
+    assert approval_code
+
+    executed = await actions.tg_set_channel_comments_join_requirement(
+        channel="@Matskevich",
+        join_required=False,
+        dry_run=False,
+        confirm=True,
+        confirmation_text="отправляй",
+        approval_code=approval_code,
+    )
+
+    assert executed["success"] is True
+    assert executed["join_required"] is False
+    assert executed["linked_group_target"] == "@matskevich_chat"
+
+
+@pytest.mark.asyncio
+async def test_delete_messages_requires_one_time_approval_code(monkeypatch, tmp_path):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
+    monkeypatch.setattr(actions, "ALLOWED_TARGETS", {"test_target"})
+    monkeypatch.setattr(actions, "REQUIRE_CONFIRMATION_TEXT", True)
+    monkeypatch.setattr(actions, "CONFIRMATION_PHRASE", "отправляй")
+    monkeypatch.setattr(actions, "REQUIRE_APPROVAL_CODE", True)
+    monkeypatch.setattr(actions, "IDEMPOTENCY_ENABLED", False)
+    monkeypatch.setattr(actions, "APPROVAL_TTL_SEC", 1800)
+    monkeypatch.setattr(actions, "APPROVAL_MIN_AGE_SEC", 0)
+    monkeypatch.setattr(actions, "APPROVAL_FILE", tmp_path / "approvals.json")
+    monkeypatch.setattr(actions, "ctx", _FakeCtx())
+
+    preview = await actions.tg_delete_messages(
+        group="test_target",
+        message_ids=[101, 102],
+        dry_run=True,
+    )
+    assert preview["success"] is True
+    approval_code = preview.get("approval_code")
+    assert approval_code
+
+    executed = await actions.tg_delete_messages(
+        group="test_target",
+        message_ids=[101, 102],
+        dry_run=False,
+        confirm=True,
+        confirmation_text="отправляй",
+        approval_code=approval_code,
+    )
+
+    assert executed["success"] is True
+    assert executed["message_count"] == 2
+    assert executed["revoke"] is True
+
+
+@pytest.mark.asyncio
+async def test_leave_dialog_requires_one_time_approval_code(monkeypatch, tmp_path):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
+    monkeypatch.setattr(actions, "ALLOWED_TARGETS", {"test_channel"})
+    monkeypatch.setattr(actions, "REQUIRE_CONFIRMATION_TEXT", True)
+    monkeypatch.setattr(actions, "CONFIRMATION_PHRASE", "отправляй")
+    monkeypatch.setattr(actions, "REQUIRE_APPROVAL_CODE", True)
+    monkeypatch.setattr(actions, "IDEMPOTENCY_ENABLED", False)
+    monkeypatch.setattr(actions, "APPROVAL_TTL_SEC", 1800)
+    monkeypatch.setattr(actions, "APPROVAL_MIN_AGE_SEC", 0)
+    monkeypatch.setattr(actions, "APPROVAL_FILE", tmp_path / "approvals.json")
+    monkeypatch.setattr(actions, "ctx", _FakeCtx())
+
+    preview = await actions.tg_leave_dialog(group="test_channel", dry_run=True)
+    assert preview["success"] is True
+    approval_code = preview.get("approval_code")
+    assert approval_code
+
+    executed = await actions.tg_leave_dialog(
+        group="test_channel",
+        dry_run=False,
+        confirm=True,
+        confirmation_text="отправляй",
+        approval_code=approval_code,
+    )
+
+    assert executed["success"] is True
+    assert executed["dry_run"] is False
+    assert executed["action"] == "leave_dialog"
+
+
+@pytest.mark.asyncio
+async def test_forward_messages_requires_allowlisted_source(monkeypatch, tmp_path):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
+    monkeypatch.setattr(actions, "ALLOWED_TARGETS", {"target_only"})
+    monkeypatch.setattr(actions, "REQUIRE_CONFIRMATION_TEXT", True)
+    monkeypatch.setattr(actions, "CONFIRMATION_PHRASE", "отправляй")
+    monkeypatch.setattr(actions, "REQUIRE_APPROVAL_CODE", False)
+    monkeypatch.setattr(actions, "IDEMPOTENCY_ENABLED", False)
+    monkeypatch.setattr(actions, "APPROVAL_FILE", tmp_path / "approvals.json")
+    monkeypatch.setattr(actions, "ctx", _FakeCtx())
+
+    blocked = await actions.tg_forward_messages(
+        from_group="source_chat",
+        to_group="target_only",
+        message_ids=[7],
+        dry_run=True,
+    )
+
+    assert blocked["success"] is False
+    assert "not in TG_ACTIONS_ALLOWED_GROUPS" in blocked["error"]

--- a/tests/test_mcp_server_actions_batch.py
+++ b/tests/test_mcp_server_actions_batch.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import pytest
@@ -5,7 +6,33 @@ import pytest
 os.environ.setdefault("TG_API_ID", "1")
 os.environ.setdefault("TG_API_HASH", "testhash")
 
-import mcp_server_actions as actions
+import mcp_server_actions as actions  # noqa: E402
+
+
+class _BatchFakeManager:
+    async def delete_messages(self, group, message_ids, revoke=True, dry_run=False):
+        return {
+            "success": True,
+            "action": "delete_messages",
+            "target": group,
+            "message_ids": list(message_ids),
+            "message_count": len(message_ids),
+            "revoke": revoke,
+            "dry_run": dry_run,
+        }
+
+    async def leave_dialog(self, group, dry_run=False):
+        return {
+            "success": True,
+            "action": "leave_dialog",
+            "target": group,
+            "dry_run": dry_run,
+        }
+
+
+class _BatchFakeCtx:
+    async def get_manager(self):
+        return _BatchFakeManager()
 
 
 def test_create_add_member_batch_record_dedup_and_policy(monkeypatch):
@@ -101,3 +128,104 @@ async def test_batch_run_lock_blocks_parallel_worker(monkeypatch, tmp_path):
     result = await actions.tg_run_add_member_batch("b1", max_actions=1)
     assert result["success"] is False
     assert "already running" in str(result.get("error", ""))
+
+
+@pytest.mark.asyncio
+async def test_create_delete_messages_batch_from_manifest_chunks_and_policy(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
+    monkeypatch.setattr(actions, "ALLOWED_TARGETS", {"good"})
+    monkeypatch.setattr(actions, "BATCH_FILE", tmp_path / "batches.json")
+
+    manifest = tmp_path / "delete_manifest.json"
+    manifest.write_text(
+        '{"targets":[{"group":"good","message_ids":[1,2,3]},{"group":"bad","message_ids":[4]}]}',
+        encoding="utf-8",
+    )
+
+    result = await actions.tg_create_delete_messages_batch_from_manifest(
+        str(manifest),
+        max_ids_per_action=2,
+    )
+
+    assert result["success"] is True
+    assert result["batch_type"] == "delete_messages"
+    assert result["total"] == 3
+    assert result["blocked_policy_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_delete_messages_batch_executes_approved_chunks(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", False)
+    monkeypatch.setattr(actions, "BATCH_FILE", tmp_path / "batches.json")
+    monkeypatch.setattr(actions, "BATCH_RUN_LEASE_SEC", 1800)
+    monkeypatch.setattr(actions, "ctx", _BatchFakeCtx())
+    monkeypatch.setattr(actions.time, "time", lambda: 100)
+
+    state = {
+        "b1": {
+            "id": "b1",
+            "type": "delete_messages",
+            "status": "approved",
+            "approved": True,
+            "approved_at_ts": 10,
+            "approved_until_ts": 9999,
+            "run_lock_owner": None,
+            "run_lock_until_ts": None,
+            "created_at_ts": 1,
+            "expires_at_ts": 9999999999,
+            "revoke": True,
+            "actions": [
+                {
+                    "group": "g1",
+                    "message_ids": [1, 2],
+                    "status": "pending",
+                    "attempts": 0,
+                }
+            ],
+        }
+    }
+    actions._save_batches_state(state)
+
+    result = await actions.tg_run_delete_messages_batch("b1", max_actions=1)
+
+    assert result["success"] is True
+    assert result["status"] == "completed"
+    assert result["success_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_leave_dialog_batch_from_candidates_uses_reviewed_candidates(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(actions, "SAFE_STARTUP_BLOCK_REASON", None)
+    monkeypatch.setattr(actions, "ACTIONS_ENABLED", True)
+    monkeypatch.setattr(actions, "REQUIRE_ALLOWLIST", True)
+    monkeypatch.setattr(actions, "ALLOWED_TARGETS", {"-1001"})
+    monkeypatch.setattr(actions, "BATCH_FILE", tmp_path / "batches.json")
+
+    candidates = tmp_path / "channel_candidates.json"
+    candidates.write_text(
+        json.dumps(
+            {
+                "candidates": [
+                    {"target": "-1001", "review": {"leave_candidate": True}},
+                    {"target": "-1002", "review": {"leave_candidate": False}},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = await actions.tg_create_leave_dialog_batch_from_candidates(str(candidates))
+
+    assert result["success"] is True
+    assert result["batch_type"] == "leave_dialog"
+    assert result["total"] == 1

--- a/tests/test_tg_action_bridge.py
+++ b/tests/test_tg_action_bridge.py
@@ -1,0 +1,171 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "tg_action_bridge.py"
+
+
+FAKE_SERVER = r"""
+import json
+import os
+import sys
+
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw:
+        continue
+    req = json.loads(raw)
+    method = req.get("method")
+    req_id = req.get("id")
+
+    if method == "initialize":
+        resp = {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "fake-actions", "version": "0.1"},
+            },
+        }
+    elif method == "notifications/initialized":
+        continue
+    elif method == "tools/list":
+        resp = {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "tools": [
+                    {"name": "tg_echo_env"},
+                    {"name": "tg_send_message"},
+                ]
+            },
+        }
+    elif method == "tools/call":
+        name = req["params"]["name"]
+        args = req["params"]["arguments"]
+        if name == "tg_echo_env":
+            body = {
+                "runtime_mode": os.environ.get("TG_SESSION_RUNTIME_MODE"),
+                "runtime_profile": os.environ.get("TG_SESSION_RUNTIME_PROFILE"),
+                "custom": os.environ.get("BRIDGE_TEST_FLAG"),
+            }
+        elif name == "tg_send_message":
+            if args.get("dry_run") is True:
+                body = {
+                    "success": True,
+                    "approval_code": "abc123",
+                    "message_text": args.get("message_text"),
+                }
+            else:
+                body = {
+                    "success": True,
+                    "confirm": args.get("confirm"),
+                    "approval_code": args.get("approval_code"),
+                    "confirmation_text": args.get("confirmation_text"),
+                    "dry_run": args.get("dry_run"),
+                    "message_text": args.get("message_text"),
+                }
+        else:
+            body = {"error": f"unknown tool {name}"}
+        resp = {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "result": {
+                "content": [{"type": "text", "text": json.dumps(body, ensure_ascii=False)}]
+            },
+        }
+    else:
+        resp = {"jsonrpc": "2.0", "id": req_id, "error": {"code": -32601, "message": method}}
+
+    sys.stdout.write(json.dumps(resp, ensure_ascii=False) + "\n")
+    sys.stdout.flush()
+"""
+
+
+def _write_fake_server(tmp_path: Path) -> Path:
+    server = tmp_path / "fake_actions_server.py"
+    server.write_text(FAKE_SERVER, encoding="utf-8")
+    return server
+
+
+def _write_config(tmp_path: Path, server_path: Path) -> Path:
+    config = tmp_path / "config.toml"
+    config.write_text(
+        "\n".join(
+            [
+                "[mcp_servers.tgmcp_actions]",
+                f'command = "{sys.executable}"',
+                f'args = ["{server_path}"]',
+                "",
+                "[mcp_servers.tgmcp_actions.env]",
+                'TG_ACTIONS_CONFIRMATION_PHRASE = "отправляй"',
+                'TG_ACTIONS_APPROVAL_MIN_AGE_SEC = "0"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_bridge_call_supports_server_alias_and_runtime_copy(tmp_path):
+    server = _write_fake_server(tmp_path)
+    config = _write_config(tmp_path, server)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--config",
+            str(config),
+            "--server",
+            "tgmcp-actions",
+            "--set-env",
+            "BRIDGE_TEST_FLAG=ok",
+            "call",
+            "tg_echo_env",
+            "--args-json",
+            "{}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["runtime_mode"] == "copy"
+    assert payload["runtime_profile"] == "actions_bridge"
+    assert payload["custom"] == "ok"
+
+
+def test_bridge_write_call_runs_preview_then_confirm(tmp_path):
+    server = _write_fake_server(tmp_path)
+    config = _write_config(tmp_path, server)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--config",
+            str(config),
+            "write-call",
+            "tg_send_message",
+            "--args-json",
+            '{"group":"@bot","message_text":"hello"}',
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["preview"]["approval_code"] == "abc123"
+    assert payload["execution"]["confirm"] is True
+    assert payload["execution"]["approval_code"] == "abc123"
+    assert payload["execution"]["confirmation_text"] == "отправляй"
+    assert payload["execution"]["dry_run"] is False
+    assert payload["execution"]["message_text"] == "hello"

--- a/tganalytics/mcp_actions_batch.py
+++ b/tganalytics/mcp_actions_batch.py
@@ -130,3 +130,154 @@ def create_add_member_batch_record(
         "last_error": None,
     }
     return batch, blocked_targets
+
+
+def _unique_targets(raw_targets: list[str]) -> list[str]:
+    unique: list[str] = []
+    seen = set()
+    for target in raw_targets:
+        value = str(target).strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        unique.append(value)
+    return unique
+
+
+def create_leave_dialog_batch_record(
+    *,
+    targets: list[str],
+    note: str,
+    ttl_hours: int,
+    check_target_allowed: Callable[[str], tuple[bool, str | None]],
+) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    """Create canonical batch record for leaving many dialogs."""
+    blocked_targets: list[dict[str, str]] = []
+    actions: list[dict[str, Any]] = []
+    for target in _unique_targets(targets):
+        allowed, error = check_target_allowed(target)
+        action_hash = hash_payload(
+            {
+                "action": "leave_dialog",
+                "target": normalize_target(target),
+            }
+        )
+        status = "pending" if allowed else "blocked_policy"
+        if not allowed:
+            blocked_targets.append({"group": target, "error": error or "blocked"})
+        actions.append(
+            {
+                "group": target,
+                "action_hash": action_hash,
+                "status": status,
+                "attempts": 0,
+                "last_error": None if allowed else error,
+                "last_run_ts": None,
+            }
+        )
+
+    now = int(time.time())
+    hours = max(1, int(ttl_hours))
+    batch_id = f"batch_{secrets.token_urlsafe(7)}"
+    batch = {
+        "id": batch_id,
+        "type": "leave_dialog",
+        "status": "pending_approval",
+        "approved": False,
+        "approved_until_ts": None,
+        "run_lock_owner": None,
+        "run_lock_until_ts": None,
+        "note": (note or "").strip(),
+        "created_at_ts": now,
+        "approved_at_ts": None,
+        "expires_at_ts": now + (hours * 3600),
+        "actions": actions,
+        "last_run_ts": None,
+        "last_error": None,
+    }
+    return batch, blocked_targets
+
+
+def create_delete_messages_batch_record(
+    *,
+    targets: list[dict[str, Any]],
+    note: str,
+    ttl_hours: int,
+    max_ids_per_action: int,
+    revoke: bool,
+    check_target_allowed: Callable[[str], tuple[bool, str | None]],
+) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    """Create canonical batch record for deleting message ids in many dialogs."""
+    blocked_targets: list[dict[str, str]] = []
+    actions: list[dict[str, Any]] = []
+    chunk_size = max(1, int(max_ids_per_action or 100))
+
+    for target_record in targets:
+        group = str(
+            target_record.get("group") or target_record.get("chat_id") or ""
+        ).strip()
+        if not group:
+            continue
+        raw_ids = target_record.get("message_ids") or []
+        message_ids: list[int] = []
+        seen_ids = set()
+        for raw_id in raw_ids:
+            try:
+                message_id = int(raw_id)
+            except Exception:
+                continue
+            if message_id <= 0 or message_id in seen_ids:
+                continue
+            seen_ids.add(message_id)
+            message_ids.append(message_id)
+        if not message_ids:
+            continue
+
+        allowed, error = check_target_allowed(group)
+        if not allowed:
+            blocked_targets.append({"group": group, "error": error or "blocked"})
+
+        for idx in range(0, len(message_ids), chunk_size):
+            chunk = message_ids[idx : idx + chunk_size]
+            action_hash = hash_payload(
+                {
+                    "action": "delete_messages",
+                    "target": normalize_target(group),
+                    "message_ids": chunk,
+                    "revoke": bool(revoke),
+                }
+            )
+            actions.append(
+                {
+                    "group": group,
+                    "message_ids": chunk,
+                    "message_count": len(chunk),
+                    "action_hash": action_hash,
+                    "status": "pending" if allowed else "blocked_policy",
+                    "attempts": 0,
+                    "last_error": None if allowed else error,
+                    "last_run_ts": None,
+                }
+            )
+
+    now = int(time.time())
+    hours = max(1, int(ttl_hours))
+    batch_id = f"batch_{secrets.token_urlsafe(7)}"
+    batch = {
+        "id": batch_id,
+        "type": "delete_messages",
+        "status": "pending_approval",
+        "approved": False,
+        "approved_until_ts": None,
+        "run_lock_owner": None,
+        "run_lock_until_ts": None,
+        "note": (note or "").strip(),
+        "created_at_ts": now,
+        "approved_at_ts": None,
+        "expires_at_ts": now + (hours * 3600),
+        "revoke": bool(revoke),
+        "actions": actions,
+        "last_run_ts": None,
+        "last_error": None,
+    }
+    return batch, blocked_targets

--- a/tganalytics/mcp_server_actions.py
+++ b/tganalytics/mcp_server_actions.py
@@ -24,20 +24,25 @@ os.environ.setdefault("TG_DIRECT_TELETHON_WRITE_ALLOWED_CONTEXTS", "actions_mcp"
 os.environ.setdefault("TG_WRITE_CONTEXT", "actions_mcp")
 os.environ.setdefault("TG_ACTION_PROCESS", "1")
 
-from mcp.server.fastmcp import FastMCP
-
-from mcp_actions_batch import create_add_member_batch_record, summarize_batch
-from mcp_actions_policy import (
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp_actions_batch import (  # noqa: E402
+    create_add_member_batch_record,
+    create_delete_messages_batch_record,
+    create_leave_dialog_batch_record,
+    summarize_batch,
+)
+from mcp_actions_policy import (  # noqa: E402
     detect_unsafe_defaults,
     hash_payload,
     normalize_target,
     parse_allowlist,
     validate_confirmation_text,
 )
-from mcp_actions_state import load_json_dict, update_json_dict
-from mcp_server_common import MCPServerContext
-from tganalytics.infra.limiter import get_rate_limiter
-from tganalytics.infra.metrics import snapshot
+from mcp_actions_state import load_json_dict, update_json_dict  # noqa: E402
+from mcp_server_common import MCPServerContext  # noqa: E402
+
+from tganalytics.infra.limiter import get_rate_limiter  # noqa: E402
+from tganalytics.infra.metrics import snapshot  # noqa: E402
 
 SERVER_NAME = os.environ.get("TG_MCP_SERVER_NAME", "tganalytics-actions")
 ALLOW_SESSION_SWITCH = os.environ.get("TG_ALLOW_SESSION_SWITCH", "0") == "1"
@@ -56,21 +61,31 @@ except ValueError:
     MAX_FILE_MB = 20
 
 try:
-    MIN_CONFIRMATION_TEXT_LEN = int(os.environ.get("TG_ACTIONS_MIN_CONFIRM_TEXT_LEN", "6"))
+    MIN_CONFIRMATION_TEXT_LEN = int(
+        os.environ.get("TG_ACTIONS_MIN_CONFIRM_TEXT_LEN", "6")
+    )
 except ValueError:
     MIN_CONFIRMATION_TEXT_LEN = 6
 
 try:
-    IDEMPOTENCY_WINDOW_SEC = int(os.environ.get("TG_ACTIONS_IDEMPOTENCY_WINDOW_SEC", str(24 * 3600)))
+    IDEMPOTENCY_WINDOW_SEC = int(
+        os.environ.get("TG_ACTIONS_IDEMPOTENCY_WINDOW_SEC", str(24 * 3600))
+    )
 except ValueError:
     IDEMPOTENCY_WINDOW_SEC = 24 * 3600
 
-REQUIRE_CONFIRMATION_TEXT = os.environ.get("TG_ACTIONS_REQUIRE_CONFIRMATION_TEXT", "1") == "1"
-CONFIRMATION_PHRASE = os.environ.get("TG_ACTIONS_CONFIRMATION_PHRASE", "отправляй").strip().lower()
+REQUIRE_CONFIRMATION_TEXT = (
+    os.environ.get("TG_ACTIONS_REQUIRE_CONFIRMATION_TEXT", "1") == "1"
+)
+CONFIRMATION_PHRASE = (
+    os.environ.get("TG_ACTIONS_CONFIRMATION_PHRASE", "отправляй").strip().lower()
+)
 REQUIRE_APPROVAL_CODE = os.environ.get("TG_ACTIONS_REQUIRE_APPROVAL_CODE", "1") == "1"
 IDEMPOTENCY_ENABLED = os.environ.get("TG_ACTIONS_IDEMPOTENCY_ENABLED", "1") == "1"
 IDEMPOTENCY_FILE = Path(
-    os.environ.get("TG_ACTIONS_IDEMPOTENCY_FILE", "data/anti_spam/action_idempotency.json")
+    os.environ.get(
+        "TG_ACTIONS_IDEMPOTENCY_FILE", "data/anti_spam/action_idempotency.json"
+    )
 )
 
 try:
@@ -83,7 +98,9 @@ try:
 except ValueError:
     APPROVAL_MIN_AGE_SEC = 30
 
-APPROVAL_FILE = Path(os.environ.get("TG_ACTIONS_APPROVAL_FILE", "data/anti_spam/action_approvals.json"))
+APPROVAL_FILE = Path(
+    os.environ.get("TG_ACTIONS_APPROVAL_FILE", "data/anti_spam/action_approvals.json")
+)
 
 try:
     BATCH_DEFAULT_TTL_HOURS = int(os.environ.get("TG_ACTIONS_BATCH_TTL_HOURS", "168"))
@@ -91,7 +108,9 @@ except ValueError:
     BATCH_DEFAULT_TTL_HOURS = 168
 
 try:
-    BATCH_APPROVAL_LEASE_SEC = int(os.environ.get("TG_ACTIONS_BATCH_APPROVAL_LEASE_SEC", str(24 * 3600)))
+    BATCH_APPROVAL_LEASE_SEC = int(
+        os.environ.get("TG_ACTIONS_BATCH_APPROVAL_LEASE_SEC", str(24 * 3600))
+    )
 except ValueError:
     BATCH_APPROVAL_LEASE_SEC = 24 * 3600
 
@@ -100,7 +119,9 @@ try:
 except ValueError:
     BATCH_RUN_LEASE_SEC = 1800
 
-BATCH_FILE = Path(os.environ.get("TG_ACTIONS_BATCH_FILE", "data/anti_spam/action_batches.json"))
+BATCH_FILE = Path(
+    os.environ.get("TG_ACTIONS_BATCH_FILE", "data/anti_spam/action_batches.json")
+)
 
 
 def _detect_unsafe_defaults() -> list[str]:
@@ -136,7 +157,9 @@ def _parse_allowlist(raw: str) -> set[str]:
 ALLOWED_TARGETS = _parse_allowlist(os.environ.get("TG_ACTIONS_ALLOWED_GROUPS", ""))
 
 mcp = FastMCP(SERVER_NAME)
-ctx = MCPServerContext(allow_session_switch=ALLOW_SESSION_SWITCH, server_profile="actions")
+ctx = MCPServerContext(
+    allow_session_switch=ALLOW_SESSION_SWITCH, server_profile="actions"
+)
 
 
 def _check_target_allowed(group: str) -> tuple[bool, str | None]:
@@ -145,7 +168,8 @@ def _check_target_allowed(group: str) -> tuple[bool, str | None]:
     if REQUIRE_ALLOWLIST and not ALLOWED_TARGETS:
         return (
             False,
-            "Actions blocked: TG_ACTIONS_REQUIRE_ALLOWLIST=1 but TG_ACTIONS_ALLOWED_GROUPS is empty.",
+            "Actions blocked: TG_ACTIONS_REQUIRE_ALLOWLIST=1 but "
+            "TG_ACTIONS_ALLOWED_GROUPS is empty.",
         )
 
     if ALLOWED_TARGETS and normalized not in ALLOWED_TARGETS:
@@ -199,7 +223,9 @@ def _suggest_next_step(error: str | None) -> str | None:
     if "actions are disabled" in text:
         return "Set TG_ACTIONS_ENABLED=1 for ActionMCP and restart server."
     if "require_allowlist=1 but tg_actions_allowed_groups is empty" in text:
-        return "Set TG_ACTIONS_ALLOWED_GROUPS with explicit targets, then retry dry_run."
+        return (
+            "Set TG_ACTIONS_ALLOWED_GROUPS with explicit targets, then retry dry_run."
+        )
     if "is not in tg_actions_allowed_groups" in text:
         return "Add this target to TG_ACTIONS_ALLOWED_GROUPS, then retry dry_run."
     if "confirm=true" in text:
@@ -211,7 +237,10 @@ def _suggest_next_step(error: str | None) -> str | None:
     if "approval_code" in text:
         return "Run matching action with dry_run=true to get one-time approval_code, then execute."
     if "duplicate action blocked" in text:
-        return "Wait until idempotency window expires or set force_resend=true if resend is intentional."
+        return (
+            "Wait until idempotency window expires or set force_resend=true "
+            "if resend is intentional."
+        )
     return None
 
 
@@ -226,6 +255,28 @@ def _blocked(error: str, **extra: Any) -> dict[str, Any]:
 
 def _hash_payload(payload: dict[str, Any]) -> str:
     return hash_payload(payload)
+
+
+def _normalize_message_ids_arg(message_ids: Any) -> list[int]:
+    raw_items = (
+        [message_ids] if isinstance(message_ids, int) else list(message_ids or [])
+    )
+    normalized: list[int] = []
+    seen = set()
+    for item in raw_items:
+        try:
+            message_id = int(item)
+        except Exception as exc:
+            raise ValueError(f"Invalid message id: {item!r}") from exc
+        if message_id <= 0:
+            raise ValueError(f"Invalid message id: {message_id}")
+        if message_id in seen:
+            continue
+        seen.add(message_id)
+        normalized.append(message_id)
+    if not normalized:
+        raise ValueError("message_ids is empty")
+    return normalized
 
 
 def _load_idempotency_state() -> dict[str, float]:
@@ -256,7 +307,9 @@ def _save_idempotency_state(state: dict[str, float]) -> None:
     update_json_dict(IDEMPOTENCY_FILE, _mut)
 
 
-def _check_recent_duplicate(action_hash: str, now_ts: float | None = None) -> tuple[bool, int]:
+def _check_recent_duplicate(
+    action_hash: str, now_ts: float | None = None
+) -> tuple[bool, int]:
     if not IDEMPOTENCY_ENABLED:
         return False, 0
     now = now_ts if now_ts is not None else time.time()
@@ -272,7 +325,9 @@ def _check_recent_duplicate(action_hash: str, now_ts: float | None = None) -> tu
                 continue
 
         # Trim stale keys while reading.
-        fresh = {k: v for k, v in normalized.items() if (now - v) <= IDEMPOTENCY_WINDOW_SEC}
+        fresh = {
+            k: v for k, v in normalized.items() if (now - v) <= IDEMPOTENCY_WINDOW_SEC
+        }
         state.clear()
         state.update(fresh)
 
@@ -297,7 +352,9 @@ def _mark_action_executed(action_hash: str, now_ts: float | None = None) -> None
     update_json_dict(IDEMPOTENCY_FILE, _mut)
 
 
-def _validate_confirmation_text(confirmation_text: str, dry_run: bool) -> tuple[bool, str | None]:
+def _validate_confirmation_text(
+    confirmation_text: str, dry_run: bool
+) -> tuple[bool, str | None]:
     return validate_confirmation_text(
         confirmation_text=confirmation_text,
         dry_run=dry_run,
@@ -357,7 +414,9 @@ def _save_approvals_state(state: dict[str, dict[str, Any]]) -> None:
     update_json_dict(APPROVAL_FILE, _mut)
 
 
-def _trim_approvals(state: dict[str, dict[str, Any]], now_ts: float | None = None) -> dict[str, dict[str, Any]]:
+def _trim_approvals(
+    state: dict[str, dict[str, Any]], now_ts: float | None = None
+) -> dict[str, dict[str, Any]]:
     now = now_ts if now_ts is not None else time.time()
     return {
         code: item
@@ -392,7 +451,9 @@ def _issue_approval(payload_hash: str, now_ts: float | None = None) -> dict[str,
     }
 
 
-def _consume_approval(payload_hash: str, approval_code: str, now_ts: float | None = None) -> tuple[bool, str | None]:
+def _consume_approval(
+    payload_hash: str, approval_code: str, now_ts: float | None = None
+) -> tuple[bool, str | None]:
     now = now_ts if now_ts is not None else time.time()
     code = (approval_code or "").strip()
 
@@ -404,7 +465,8 @@ def _consume_approval(payload_hash: str, approval_code: str, now_ts: float | Non
         if not code:
             return (
                 False,
-                "Execution blocked: approval_code is required. Run the same action with dry_run=true first.",
+                "Execution blocked: approval_code is required. "
+                "Run the same action with dry_run=true first.",
             )
 
         item = state.get(code)
@@ -413,7 +475,8 @@ def _consume_approval(payload_hash: str, approval_code: str, now_ts: float | Non
         if item.get("digest") != payload_hash:
             return (
                 False,
-                "Execution blocked: approval_code does not match this payload. Generate a fresh dry_run preview.",
+                "Execution blocked: approval_code does not match this payload. "
+                "Generate a fresh dry_run preview.",
             )
         issued_at = float(item.get("issued_at") or 0.0)
         earliest_exec_ts = issued_at + max(0, APPROVAL_MIN_AGE_SEC)
@@ -460,7 +523,9 @@ def _save_batches_state(state: dict[str, dict[str, Any]]) -> None:
     update_json_dict(BATCH_FILE, _mut, root_key="batches")
 
 
-def _get_batch(batch_id: str) -> tuple[dict[str, dict[str, Any]], dict[str, Any] | None]:
+def _get_batch(
+    batch_id: str,
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any] | None]:
     state = _load_batches_state()
     batch = state.get((batch_id or "").strip())
     return state, batch
@@ -470,7 +535,9 @@ def _batch_run_owner() -> str:
     return f"{SERVER_NAME}:{os.getpid()}"
 
 
-def _acquire_batch_run_lock(batch_id: str, now_ts: int | None = None) -> tuple[bool, str | None]:
+def _acquire_batch_run_lock(
+    batch_id: str, now_ts: int | None = None
+) -> tuple[bool, str | None]:
     now = int(now_ts if now_ts is not None else time.time())
     owner = _batch_run_owner()
     bid = (batch_id or "").strip()
@@ -539,6 +606,121 @@ def _create_add_member_batch_record(
     )
 
 
+def _create_delete_messages_batch_record(
+    targets: list[dict[str, Any]],
+    note: str,
+    ttl_hours: int,
+    max_ids_per_action: int,
+    revoke: bool,
+) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    return create_delete_messages_batch_record(
+        targets=targets,
+        note=note,
+        ttl_hours=ttl_hours,
+        max_ids_per_action=max_ids_per_action,
+        revoke=revoke,
+        check_target_allowed=_check_target_allowed,
+    )
+
+
+def _create_leave_dialog_batch_record(
+    targets: list[str],
+    note: str,
+    ttl_hours: int,
+) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    return create_leave_dialog_batch_record(
+        targets=targets,
+        note=note,
+        ttl_hours=ttl_hours,
+        check_target_allowed=_check_target_allowed,
+    )
+
+
+@mcp.tool()
+async def tg_create_private_group(
+    title: str,
+    users: list[str] | None = None,
+    about: str = "",
+    kind: str = "basic",
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirmation_text: str = "",
+    approval_code: str = "",
+    force_resend: bool = False,
+) -> dict:
+    """Create a private supergroup with confirmation and idempotency gates."""
+    clean_title = str(title or "").strip()
+    if not clean_title:
+        return _blocked("title is empty")
+    group_kind = str(kind or "basic").strip().lower()
+    if group_kind not in {"basic", "supergroup"}:
+        return _blocked("kind must be 'basic' or 'supergroup'")
+
+    can_run, error = _check_action_preconditions(
+        clean_title,
+        dry_run=dry_run,
+        confirm=confirm,
+        confirmation_text=confirmation_text,
+    )
+    if not can_run:
+        return _blocked(error or "preconditions failed")
+
+    normalized_users = [
+        str(user).strip().lower() for user in (users or []) if str(user).strip()
+    ]
+    action_hash = _hash_payload(
+        {
+            "action": "create_private_group",
+            "target": _normalize_target(clean_title),
+            "users": normalized_users,
+            "about": str(about or "").strip(),
+            "kind": group_kind,
+        }
+    )
+
+    approval_ok, approval_error, approval_meta = _approval_gate(
+        action_hash=action_hash,
+        dry_run=dry_run,
+        approval_code=approval_code,
+    )
+    if not approval_ok:
+        return _blocked(approval_error or "approval gate blocked")
+
+    if not dry_run and not force_resend:
+        duplicate, retry_after_sec = _check_recent_duplicate(action_hash)
+        if duplicate:
+            return {
+                "success": False,
+                "duplicate_blocked": True,
+                "retry_after_sec": retry_after_sec,
+                "action_hash": action_hash,
+                "error": "Duplicate action blocked by idempotency window. "
+                "Set force_resend=true to override.",
+            }
+
+    manager = await ctx.get_manager()
+    try:
+        result = await manager.create_private_group(
+            clean_title,
+            users=list(users or []),
+            about=about,
+            kind=group_kind,
+            dry_run=dry_run,
+        )
+    except Exception as exc:
+        return _blocked(str(exc))
+
+    if not dry_run and result.get("success"):
+        _mark_action_executed(action_hash)
+    if dry_run and approval_meta:
+        result.update(approval_meta)
+    result["action_hash"] = action_hash
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
+    return result
+
+
 @mcp.tool()
 async def tg_list_sessions() -> dict:
     """List available Telegram sessions in data/sessions/."""
@@ -573,6 +755,102 @@ async def tg_get_my_dialogs(limit: int = 100, dialog_type: str = "all") -> dict:
     manager = await ctx.get_manager()
     dialogs = await manager.get_my_dialogs(limit=limit, dialog_type=dialog_type)
     return {"count": len(dialogs), "dialogs": dialogs}
+
+
+@mcp.tool()
+async def tg_set_channel_comments_join_requirement(
+    channel: str,
+    join_required: bool = False,
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirmation_text: str = "",
+    approval_code: str = "",
+    force_resend: bool = False,
+) -> dict:
+    """Toggle whether comments require joining the linked discussion group first."""
+    manager = await ctx.get_manager()
+    preview = await manager.set_channel_comments_join_requirement(
+        channel_identifier=channel,
+        join_required=join_required,
+        dry_run=True,
+    )
+    if not preview.get("success"):
+        return preview
+
+    linked_group_target = str(preview.get("linked_group_target") or "").strip()
+    can_run, error = _check_action_preconditions(
+        linked_group_target,
+        dry_run=dry_run,
+        confirm=confirm,
+        confirmation_text=confirmation_text,
+    )
+    if not can_run:
+        return _blocked(
+            error or "preconditions failed",
+            channel=channel,
+            join_required=bool(join_required),
+            linked_group_target=linked_group_target,
+            linked_group_id=preview.get("linked_group_id"),
+            linked_group_title=preview.get("linked_group_title"),
+            current_join_required=preview.get("current_join_required"),
+        )
+
+    action_hash = _hash_payload(
+        {
+            "action": "set_channel_comments_join_requirement",
+            "channel": _normalize_target(str(preview.get("channel_target") or channel)),
+            "linked_group": _normalize_target(linked_group_target),
+            "join_required": bool(join_required),
+        }
+    )
+
+    approval_ok, approval_error, approval_meta = _approval_gate(
+        action_hash=action_hash,
+        dry_run=dry_run,
+        approval_code=approval_code,
+    )
+    if not approval_ok:
+        return _blocked(
+            approval_error or "approval gate blocked",
+            channel=channel,
+            join_required=bool(join_required),
+            linked_group_target=linked_group_target,
+        )
+
+    if dry_run:
+        result = dict(preview)
+        result["action_hash"] = action_hash
+        result["confirmation_text_required"] = (
+            CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+        )
+        if approval_meta:
+            result.update(approval_meta)
+        return result
+
+    if not force_resend:
+        duplicate, retry_after_sec = _check_recent_duplicate(action_hash)
+        if duplicate:
+            return {
+                "success": False,
+                "duplicate_blocked": True,
+                "retry_after_sec": retry_after_sec,
+                "action_hash": action_hash,
+                "error": "Duplicate action blocked by idempotency window. "
+                "Set force_resend=true to override.",
+            }
+
+    result = await manager.set_channel_comments_join_requirement(
+        channel_identifier=channel,
+        join_required=join_required,
+        dry_run=False,
+    )
+    result["action_hash"] = action_hash
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
+    if result.get("success"):
+        _mark_action_executed(action_hash)
+    return result
 
 
 @mcp.tool()
@@ -628,7 +906,9 @@ async def tg_send_message(
             "target": group,
             "message_len": len(clean_text),
             "action_hash": action_hash,
-            "confirmation_text_required": CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None,
+            "confirmation_text_required": (
+                CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+            ),
         }
         if approval_meta:
             result.update(approval_meta)
@@ -738,7 +1018,9 @@ async def tg_send_file(
             "file_size_mb": round(file_size_mb, 3),
             "caption_len": len(clean_caption),
             "action_hash": action_hash,
-            "confirmation_text_required": CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None,
+            "confirmation_text_required": (
+                CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+            ),
         }
         if approval_meta:
             result.update(approval_meta)
@@ -775,6 +1057,441 @@ async def tg_send_file(
         "action_hash": action_hash,
         "error": "send_file failed (see server logs for details)",
     }
+
+
+@mcp.tool()
+async def tg_delete_messages(
+    group: str,
+    message_ids: list[int],
+    revoke: bool = True,
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirmation_text: str = "",
+    approval_code: str = "",
+    force_resend: bool = False,
+) -> dict:
+    """Delete specific messages in a dialog/group with policy gates."""
+    can_run, error = _check_action_preconditions(
+        group,
+        dry_run=dry_run,
+        confirm=confirm,
+        confirmation_text=confirmation_text,
+    )
+    if not can_run:
+        return _blocked(error or "preconditions failed")
+
+    try:
+        normalized_ids = _normalize_message_ids_arg(message_ids)
+    except ValueError as exc:
+        return _blocked(str(exc))
+
+    action_hash = _hash_payload(
+        {
+            "action": "delete_messages",
+            "target": _normalize_target(group),
+            "message_ids": normalized_ids,
+            "revoke": bool(revoke),
+        }
+    )
+
+    approval_ok, approval_error, approval_meta = _approval_gate(
+        action_hash=action_hash,
+        dry_run=dry_run,
+        approval_code=approval_code,
+    )
+    if not approval_ok:
+        return _blocked(approval_error or "approval gate blocked")
+
+    if dry_run:
+        manager = await ctx.get_manager()
+        result = await manager.delete_messages(
+            group, normalized_ids, revoke=bool(revoke), dry_run=True
+        )
+        result["action_hash"] = action_hash
+        result["confirmation_text_required"] = (
+            CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+        )
+        if approval_meta:
+            result.update(approval_meta)
+        return result
+
+    if not force_resend:
+        duplicate, retry_after_sec = _check_recent_duplicate(action_hash)
+        if duplicate:
+            return {
+                "success": False,
+                "duplicate_blocked": True,
+                "retry_after_sec": retry_after_sec,
+                "action_hash": action_hash,
+                "error": "Duplicate action blocked by idempotency window. "
+                "Set force_resend=true to override.",
+            }
+
+    manager = await ctx.get_manager()
+    result = await manager.delete_messages(
+        group, normalized_ids, revoke=bool(revoke), dry_run=False
+    )
+    result["action_hash"] = action_hash
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
+    if result.get("success"):
+        _mark_action_executed(action_hash)
+    return result
+
+
+@mcp.tool()
+async def tg_clear_history(
+    group: str,
+    max_id: int = 0,
+    revoke: bool = True,
+    just_clear: bool = False,
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirmation_text: str = "",
+    approval_code: str = "",
+    force_resend: bool = False,
+) -> dict:
+    """Clear dialog history via DeleteHistoryRequest with policy gates."""
+    can_run, error = _check_action_preconditions(
+        group,
+        dry_run=dry_run,
+        confirm=confirm,
+        confirmation_text=confirmation_text,
+    )
+    if not can_run:
+        return _blocked(error or "preconditions failed")
+
+    try:
+        normalized_max_id = int(max_id or 0)
+    except Exception:
+        return _blocked(f"Invalid max_id: {max_id!r}")
+    if normalized_max_id < 0:
+        return _blocked("max_id must be >= 0")
+
+    action_hash = _hash_payload(
+        {
+            "action": "clear_history",
+            "target": _normalize_target(group),
+            "max_id": normalized_max_id,
+            "revoke": bool(revoke),
+            "just_clear": bool(just_clear),
+        }
+    )
+
+    approval_ok, approval_error, approval_meta = _approval_gate(
+        action_hash=action_hash,
+        dry_run=dry_run,
+        approval_code=approval_code,
+    )
+    if not approval_ok:
+        return _blocked(approval_error or "approval gate blocked")
+
+    if dry_run:
+        manager = await ctx.get_manager()
+        result = await manager.clear_history(
+            group,
+            max_id=normalized_max_id,
+            revoke=bool(revoke),
+            just_clear=bool(just_clear),
+            dry_run=True,
+        )
+        result["action_hash"] = action_hash
+        result["confirmation_text_required"] = (
+            CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+        )
+        if approval_meta:
+            result.update(approval_meta)
+        return result
+
+    if not force_resend:
+        duplicate, retry_after_sec = _check_recent_duplicate(action_hash)
+        if duplicate:
+            return {
+                "success": False,
+                "duplicate_blocked": True,
+                "retry_after_sec": retry_after_sec,
+                "action_hash": action_hash,
+                "error": "Duplicate action blocked by idempotency window. "
+                "Set force_resend=true to override.",
+            }
+
+    manager = await ctx.get_manager()
+    result = await manager.clear_history(
+        group,
+        max_id=normalized_max_id,
+        revoke=bool(revoke),
+        just_clear=bool(just_clear),
+        dry_run=False,
+    )
+    result["action_hash"] = action_hash
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
+    if result.get("success"):
+        _mark_action_executed(action_hash)
+    return result
+
+
+@mcp.tool()
+async def tg_leave_dialog(
+    group: str,
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirmation_text: str = "",
+    approval_code: str = "",
+    force_resend: bool = False,
+) -> dict:
+    """Leave a channel/group with policy gates. Direct user dialogs are not leaveable."""
+    can_run, error = _check_action_preconditions(
+        group,
+        dry_run=dry_run,
+        confirm=confirm,
+        confirmation_text=confirmation_text,
+    )
+    if not can_run:
+        return _blocked(error or "preconditions failed")
+
+    action_hash = _hash_payload(
+        {
+            "action": "leave_dialog",
+            "target": _normalize_target(group),
+        }
+    )
+
+    approval_ok, approval_error, approval_meta = _approval_gate(
+        action_hash=action_hash,
+        dry_run=dry_run,
+        approval_code=approval_code,
+    )
+    if not approval_ok:
+        return _blocked(approval_error or "approval gate blocked")
+
+    if not dry_run and not force_resend:
+        duplicate, retry_after_sec = _check_recent_duplicate(action_hash)
+        if duplicate:
+            return {
+                "success": False,
+                "duplicate_blocked": True,
+                "retry_after_sec": retry_after_sec,
+                "action_hash": action_hash,
+                "error": "Duplicate action blocked by idempotency window. "
+                "Set force_resend=true to override.",
+            }
+
+    manager = await ctx.get_manager()
+    result = await manager.leave_dialog(group, dry_run=dry_run)
+    result["action_hash"] = action_hash
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
+    if dry_run and approval_meta:
+        result.update(approval_meta)
+    if not dry_run and result.get("success"):
+        _mark_action_executed(action_hash)
+    return result
+
+
+@mcp.tool()
+async def tg_edit_message(
+    group: str,
+    message_id: int,
+    new_text: str,
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirmation_text: str = "",
+    approval_code: str = "",
+    force_resend: bool = False,
+) -> dict:
+    """Edit a message in a dialog/group with policy gates."""
+    can_run, error = _check_action_preconditions(
+        group,
+        dry_run=dry_run,
+        confirm=confirm,
+        confirmation_text=confirmation_text,
+    )
+    if not can_run:
+        return _blocked(error or "preconditions failed")
+
+    try:
+        normalized_message_id = int(message_id)
+    except Exception:
+        return _blocked(f"Invalid message_id: {message_id!r}")
+    if normalized_message_id <= 0:
+        return _blocked("message_id must be > 0")
+
+    clean_text = (new_text or "").strip()
+    if not clean_text:
+        return _blocked("new_text is empty")
+    if len(clean_text) > MAX_MESSAGE_LEN:
+        return {
+            "success": False,
+            "error": f"new_text is too long ({len(clean_text)} > {MAX_MESSAGE_LEN})",
+        }
+
+    action_hash = _hash_payload(
+        {
+            "action": "edit_message",
+            "target": _normalize_target(group),
+            "message_id": normalized_message_id,
+            "new_text": clean_text,
+        }
+    )
+
+    approval_ok, approval_error, approval_meta = _approval_gate(
+        action_hash=action_hash,
+        dry_run=dry_run,
+        approval_code=approval_code,
+    )
+    if not approval_ok:
+        return _blocked(approval_error or "approval gate blocked")
+
+    if dry_run:
+        manager = await ctx.get_manager()
+        result = await manager.edit_message(
+            group,
+            message_id=normalized_message_id,
+            new_text=clean_text,
+            dry_run=True,
+        )
+        result["action_hash"] = action_hash
+        result["confirmation_text_required"] = (
+            CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+        )
+        if approval_meta:
+            result.update(approval_meta)
+        return result
+
+    if not force_resend:
+        duplicate, retry_after_sec = _check_recent_duplicate(action_hash)
+        if duplicate:
+            return {
+                "success": False,
+                "duplicate_blocked": True,
+                "retry_after_sec": retry_after_sec,
+                "action_hash": action_hash,
+                "error": "Duplicate action blocked by idempotency window. "
+                "Set force_resend=true to override.",
+            }
+
+    manager = await ctx.get_manager()
+    result = await manager.edit_message(
+        group,
+        message_id=normalized_message_id,
+        new_text=clean_text,
+        dry_run=False,
+    )
+    result["action_hash"] = action_hash
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
+    if result.get("success"):
+        _mark_action_executed(action_hash)
+    return result
+
+
+@mcp.tool()
+async def tg_forward_messages(
+    from_group: str,
+    to_group: str,
+    message_ids: list[int],
+    drop_author: bool = False,
+    drop_media_captions: bool = False,
+    dry_run: bool = True,
+    confirm: bool = False,
+    confirmation_text: str = "",
+    approval_code: str = "",
+    force_resend: bool = False,
+) -> dict:
+    """Forward messages between dialogs with policy gates."""
+    if SAFE_STARTUP_BLOCK_REASON:
+        return _blocked(SAFE_STARTUP_BLOCK_REASON)
+    if not ACTIONS_ENABLED:
+        return _blocked("Actions are disabled. Set TG_ACTIONS_ENABLED=1.")
+
+    allowed_source, source_error = _check_target_allowed(from_group)
+    if not allowed_source:
+        return _blocked(source_error or "source target is not allowed")
+
+    can_run, error = _check_action_preconditions(
+        to_group,
+        dry_run=dry_run,
+        confirm=confirm,
+        confirmation_text=confirmation_text,
+    )
+    if not can_run:
+        return _blocked(error or "preconditions failed")
+
+    try:
+        normalized_ids = _normalize_message_ids_arg(message_ids)
+    except ValueError as exc:
+        return _blocked(str(exc))
+
+    action_hash = _hash_payload(
+        {
+            "action": "forward_messages",
+            "from_target": _normalize_target(from_group),
+            "to_target": _normalize_target(to_group),
+            "message_ids": normalized_ids,
+            "drop_author": bool(drop_author),
+            "drop_media_captions": bool(drop_media_captions),
+        }
+    )
+
+    approval_ok, approval_error, approval_meta = _approval_gate(
+        action_hash=action_hash,
+        dry_run=dry_run,
+        approval_code=approval_code,
+    )
+    if not approval_ok:
+        return _blocked(approval_error or "approval gate blocked")
+
+    if dry_run:
+        manager = await ctx.get_manager()
+        result = await manager.forward_messages(
+            from_group,
+            to_group,
+            normalized_ids,
+            drop_author=bool(drop_author),
+            drop_media_captions=bool(drop_media_captions),
+            dry_run=True,
+        )
+        result["action_hash"] = action_hash
+        result["confirmation_text_required"] = (
+            CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+        )
+        if approval_meta:
+            result.update(approval_meta)
+        return result
+
+    if not force_resend:
+        duplicate, retry_after_sec = _check_recent_duplicate(action_hash)
+        if duplicate:
+            return {
+                "success": False,
+                "duplicate_blocked": True,
+                "retry_after_sec": retry_after_sec,
+                "action_hash": action_hash,
+                "error": "Duplicate action blocked by idempotency window. "
+                "Set force_resend=true to override.",
+            }
+
+    manager = await ctx.get_manager()
+    result = await manager.forward_messages(
+        from_group,
+        to_group,
+        normalized_ids,
+        drop_author=bool(drop_author),
+        drop_media_captions=bool(drop_media_captions),
+        dry_run=False,
+    )
+    result["action_hash"] = action_hash
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
+    if result.get("success"):
+        _mark_action_executed(action_hash)
+    return result
 
 
 @mcp.tool()
@@ -832,7 +1549,9 @@ async def tg_add_member_to_group(
     if dry_run and approval_meta:
         result.update(approval_meta)
     result["action_hash"] = action_hash
-    result["confirmation_text_required"] = CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
     return result
 
 
@@ -891,7 +1610,9 @@ async def tg_remove_member_from_group(
     if dry_run and approval_meta:
         result.update(approval_meta)
     result["action_hash"] = action_hash
-    result["confirmation_text_required"] = CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
     return result
 
 
@@ -957,8 +1678,52 @@ async def tg_migrate_member(
     if dry_run and approval_meta:
         result.update(approval_meta)
     result["action_hash"] = action_hash
-    result["confirmation_text_required"] = CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    result["confirmation_text_required"] = (
+        CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+    )
     return result
+
+
+def _load_json_file(path_arg: str) -> Any:
+    path = Path((path_arg or "").strip()).expanduser()
+    if not path.exists():
+        raise ValueError(f"path does not exist: {path}")
+    if not path.is_file():
+        raise ValueError(f"path is not a file: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _manifest_targets(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict) and isinstance(payload.get("targets"), list):
+        return [item for item in payload["targets"] if isinstance(item, dict)]
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    return []
+
+
+def _leave_targets_from_candidates(payload: Any) -> list[str]:
+    if isinstance(payload, dict):
+        raw_items = payload.get("candidates") or payload.get("targets") or []
+    elif isinstance(payload, list):
+        raw_items = payload
+    else:
+        raw_items = []
+
+    targets: list[str] = []
+    for item in raw_items:
+        if isinstance(item, str):
+            targets.append(item)
+            continue
+        if not isinstance(item, dict):
+            continue
+        review = item.get("review") if isinstance(item.get("review"), dict) else {}
+        approved = bool(item.get("leave_candidate") or review.get("leave_candidate"))
+        if not approved:
+            continue
+        target = item.get("target") or item.get("group") or item.get("chat_id")
+        if target is not None:
+            targets.append(str(target))
+    return targets
 
 
 @mcp.tool()
@@ -979,7 +1744,9 @@ async def tg_create_add_member_batch(
     if not groups:
         return _blocked("groups list is empty")
 
-    batch, blocked_targets = _create_add_member_batch_record(user=user, groups=groups, note=note, ttl_hours=ttl_hours)
+    batch, blocked_targets = _create_add_member_batch_record(
+        user=user, groups=groups, note=note, ttl_hours=ttl_hours
+    )
     state = _load_batches_state()
     state[batch["id"]] = batch
     _save_batches_state(state)
@@ -987,7 +1754,90 @@ async def tg_create_add_member_batch(
     summary = _summarize_batch(batch)
     summary["blocked_targets"] = blocked_targets
     summary["next_step"] = (
-        "Call tg_approve_batch(batch_id, confirmation_text), then tg_run_add_member_batch(batch_id)."
+        "Call tg_approve_batch(batch_id, confirmation_text), "
+        "then tg_run_add_member_batch(batch_id)."
+    )
+    return {"success": True, **summary}
+
+
+@mcp.tool()
+async def tg_create_delete_messages_batch_from_manifest(
+    manifest_path: str,
+    note: str = "",
+    max_ids_per_action: int = 100,
+    revoke: bool = True,
+    ttl_hours: int = BATCH_DEFAULT_TTL_HOURS,
+) -> dict:
+    """Create approved-later delete batch from privacy scrubber delete_manifest.json."""
+    if SAFE_STARTUP_BLOCK_REASON:
+        return _blocked(SAFE_STARTUP_BLOCK_REASON)
+    if not ACTIONS_ENABLED:
+        return _blocked("Actions are disabled. Set TG_ACTIONS_ENABLED=1.")
+
+    try:
+        payload = _load_json_file(manifest_path)
+    except Exception as exc:
+        return _blocked(f"failed to load manifest: {exc}")
+    targets = _manifest_targets(payload)
+    if not targets:
+        return _blocked("manifest has no valid targets")
+
+    batch, blocked_targets = _create_delete_messages_batch_record(
+        targets=targets,
+        note=note or f"from_manifest:{Path(manifest_path).name}",
+        ttl_hours=ttl_hours,
+        max_ids_per_action=max_ids_per_action,
+        revoke=revoke,
+    )
+    if not batch.get("actions"):
+        return _blocked("manifest produced no delete actions")
+    state = _load_batches_state()
+    state[batch["id"]] = batch
+    _save_batches_state(state)
+
+    summary = _summarize_batch(batch)
+    summary["blocked_targets"] = blocked_targets
+    summary["next_step"] = (
+        "Call tg_approve_batch(batch_id, confirmation_text), "
+        "then tg_run_delete_messages_batch(batch_id)."
+    )
+    return {"success": True, **summary}
+
+
+@mcp.tool()
+async def tg_create_leave_dialog_batch_from_candidates(
+    candidates_path: str,
+    note: str = "",
+    ttl_hours: int = BATCH_DEFAULT_TTL_HOURS,
+) -> dict:
+    """Create approved-later leave-dialog batch from reviewed channel_candidates.json."""
+    if SAFE_STARTUP_BLOCK_REASON:
+        return _blocked(SAFE_STARTUP_BLOCK_REASON)
+    if not ACTIONS_ENABLED:
+        return _blocked("Actions are disabled. Set TG_ACTIONS_ENABLED=1.")
+
+    try:
+        payload = _load_json_file(candidates_path)
+    except Exception as exc:
+        return _blocked(f"failed to load candidates: {exc}")
+    targets = _leave_targets_from_candidates(payload)
+    if not targets:
+        return _blocked("candidates file has no leave_candidate=true targets")
+
+    batch, blocked_targets = _create_leave_dialog_batch_record(
+        targets=targets,
+        note=note or f"from_candidates:{Path(candidates_path).name}",
+        ttl_hours=ttl_hours,
+    )
+    state = _load_batches_state()
+    state[batch["id"]] = batch
+    _save_batches_state(state)
+
+    summary = _summarize_batch(batch)
+    summary["blocked_targets"] = blocked_targets
+    summary["next_step"] = (
+        "Call tg_approve_batch(batch_id, confirmation_text), "
+        "then tg_run_leave_dialog_batch(batch_id)."
     )
     return {"success": True, **summary}
 
@@ -1096,6 +1946,271 @@ async def tg_get_batch_status(batch_id: str) -> dict:
     return {"success": True, **summary}
 
 
+def _batch_preflight(
+    batch_id: str, max_actions: int, expected_type: str
+) -> tuple[
+    dict[str, dict[str, Any]] | None, dict[str, Any] | None, dict[str, Any] | None
+]:
+    if SAFE_STARTUP_BLOCK_REASON:
+        return None, None, _blocked(SAFE_STARTUP_BLOCK_REASON)
+    if not ACTIONS_ENABLED:
+        return None, None, _blocked("Actions are disabled. Set TG_ACTIONS_ENABLED=1.")
+    if max_actions <= 0:
+        return None, None, _blocked("max_actions must be > 0")
+
+    state, batch = _get_batch(batch_id)
+    if not batch:
+        return None, None, _blocked(f"batch '{batch_id}' not found")
+    if batch.get("type") != expected_type:
+        return (
+            None,
+            None,
+            _blocked(
+                f"batch '{batch_id}' has type {batch.get('type')!r}, expected {expected_type!r}",
+                **_summarize_batch(batch),
+            ),
+        )
+    return state, batch, None
+
+
+def _mark_batch_not_runnable(
+    state: dict[str, dict[str, Any]],
+    batch: dict[str, Any],
+    *,
+    status: str,
+    error: str,
+    now: int,
+) -> dict:
+    batch["status"] = status
+    if status == "pending_approval":
+        batch["approved"] = False
+    batch["last_error"] = error
+    batch["run_lock_owner"] = None
+    batch["run_lock_until_ts"] = now
+    state[batch["id"]] = batch
+    _save_batches_state(state)
+    return _blocked(error, **_summarize_batch(batch))
+
+
+def _finalize_batch_run(
+    state: dict[str, dict[str, Any]],
+    batch: dict[str, Any],
+    *,
+    now: int,
+    processed_now: int,
+    stopped_reason: str | None,
+) -> dict:
+    pending_left = any(a.get("status") == "pending" for a in batch.get("actions", []))
+    if batch.get("status") == "running":
+        batch["status"] = "approved" if pending_left else "completed"
+    if batch.get("status") == "completed":
+        batch["completed_at_ts"] = now
+    batch["last_run_ts"] = now
+    batch["run_lock_owner"] = None
+    batch["run_lock_until_ts"] = now
+    state[batch["id"]] = batch
+    _save_batches_state(state)
+    summary = _summarize_batch(batch)
+    summary["processed_now"] = processed_now
+    summary["stopped_reason"] = stopped_reason
+    summary["last_error"] = batch.get("last_error")
+    return {"success": True, **summary}
+
+
+def _prepare_batch_for_run(
+    batch_id: str, max_actions: int, expected_type: str
+) -> tuple[
+    dict[str, dict[str, Any]] | None,
+    dict[str, Any] | None,
+    int | None,
+    dict[str, Any] | None,
+]:
+    state, batch, blocked = _batch_preflight(batch_id, max_actions, expected_type)
+    if blocked:
+        return None, None, None, blocked
+    assert batch is not None
+    now = int(time.time())
+    lock_ok, lock_error = _acquire_batch_run_lock(batch_id, now_ts=now)
+    if not lock_ok:
+        return (
+            None,
+            None,
+            None,
+            _blocked(
+                lock_error or "failed to acquire batch run lock",
+                **_summarize_batch(batch),
+            ),
+        )
+
+    state, batch = _get_batch(batch_id)
+    if not batch:
+        return None, None, None, _blocked(f"batch '{batch_id}' not found")
+
+    if int(batch.get("expires_at_ts", 0)) <= now:
+        return (
+            state,
+            batch,
+            now,
+            _mark_batch_not_runnable(
+                state, batch, status="expired", error="batch is expired", now=now
+            ),
+        )
+    if not bool(batch.get("approved", False)):
+        return (
+            state,
+            batch,
+            now,
+            _mark_batch_not_runnable(
+                state,
+                batch,
+                status="pending_approval",
+                error="batch is not approved; call tg_approve_batch first",
+                now=now,
+            ),
+        )
+    approved_until_ts = int(batch.get("approved_until_ts") or 0)
+    if approved_until_ts <= now:
+        return (
+            state,
+            batch,
+            now,
+            _mark_batch_not_runnable(
+                state,
+                batch,
+                status="pending_approval",
+                error="batch approval expired; call tg_approve_batch again",
+                now=now,
+            ),
+        )
+    if batch.get("status") == "completed":
+        batch["run_lock_owner"] = None
+        batch["run_lock_until_ts"] = now
+        state[batch["id"]] = batch
+        _save_batches_state(state)
+        return (
+            state,
+            batch,
+            now,
+            {
+                "success": True,
+                "message": "batch already completed",
+                **_summarize_batch(batch),
+            },
+        )
+    return state, batch, now, None
+
+
+@mcp.tool()
+async def tg_run_delete_messages_batch(batch_id: str, max_actions: int = 25) -> dict:
+    """Execute approved delete-messages batch without per-action confirmations."""
+    state, batch, now, blocked = _prepare_batch_for_run(
+        batch_id, max_actions, "delete_messages"
+    )
+    if blocked:
+        return blocked
+    assert state is not None and batch is not None and now is not None
+
+    manager = await ctx.get_manager()
+    processed_now = 0
+    stopped_reason = None
+    batch["status"] = "running"
+    batch["last_error"] = None
+
+    for action in batch.get("actions", []):
+        if processed_now >= int(max_actions):
+            break
+        if action.get("status") != "pending":
+            continue
+        group = str(action.get("group"))
+        allowed, allowed_error = _check_target_allowed(group)
+        if not allowed:
+            action["status"] = "blocked_policy"
+            action["last_error"] = allowed_error
+            action["last_run_ts"] = now
+            processed_now += 1
+            continue
+
+        result = await manager.delete_messages(
+            group,
+            action.get("message_ids") or [],
+            revoke=bool(batch.get("revoke", True)),
+            dry_run=False,
+        )
+        action["attempts"] = int(action.get("attempts", 0)) + 1
+        action["last_run_ts"] = now
+        if result.get("success"):
+            action["status"] = "success"
+            action["last_error"] = None
+            _mark_action_executed(str(action.get("action_hash", "")))
+        else:
+            err_text = str(result.get("error", "unknown error"))
+            action["status"] = "failed"
+            action["last_error"] = err_text
+            batch["last_error"] = err_text
+        processed_now += 1
+
+    return _finalize_batch_run(
+        state,
+        batch,
+        now=now,
+        processed_now=processed_now,
+        stopped_reason=stopped_reason,
+    )
+
+
+@mcp.tool()
+async def tg_run_leave_dialog_batch(batch_id: str, max_actions: int = 20) -> dict:
+    """Execute approved leave-dialog batch without per-action confirmations."""
+    state, batch, now, blocked = _prepare_batch_for_run(
+        batch_id, max_actions, "leave_dialog"
+    )
+    if blocked:
+        return blocked
+    assert state is not None and batch is not None and now is not None
+
+    manager = await ctx.get_manager()
+    processed_now = 0
+    stopped_reason = None
+    batch["status"] = "running"
+    batch["last_error"] = None
+
+    for action in batch.get("actions", []):
+        if processed_now >= int(max_actions):
+            break
+        if action.get("status") != "pending":
+            continue
+        group = str(action.get("group"))
+        allowed, allowed_error = _check_target_allowed(group)
+        if not allowed:
+            action["status"] = "blocked_policy"
+            action["last_error"] = allowed_error
+            action["last_run_ts"] = now
+            processed_now += 1
+            continue
+
+        result = await manager.leave_dialog(group, dry_run=False)
+        action["attempts"] = int(action.get("attempts", 0)) + 1
+        action["last_run_ts"] = now
+        if result.get("success"):
+            action["status"] = "success"
+            action["last_error"] = None
+            _mark_action_executed(str(action.get("action_hash", "")))
+        else:
+            err_text = str(result.get("error", "unknown error"))
+            action["status"] = "failed"
+            action["last_error"] = err_text
+            batch["last_error"] = err_text
+        processed_now += 1
+
+    return _finalize_batch_run(
+        state,
+        batch,
+        now=now,
+        processed_now=processed_now,
+        stopped_reason=stopped_reason,
+    )
+
+
 @mcp.tool()
 async def tg_run_add_member_batch(batch_id: str, max_actions: int = 100) -> dict:
     """Execute approved add-member batch without per-action confirmations."""
@@ -1114,7 +2229,9 @@ async def tg_run_add_member_batch(batch_id: str, max_actions: int = 100) -> dict
     now = int(time.time())
     lock_ok, lock_error = _acquire_batch_run_lock(batch_id, now_ts=now)
     if not lock_ok:
-        return _blocked(lock_error or "failed to acquire batch run lock", **_summarize_batch(batch))
+        return _blocked(
+            lock_error or "failed to acquire batch run lock", **_summarize_batch(batch)
+        )
 
     try:
         state, batch = _get_batch(batch_id)
@@ -1134,7 +2251,10 @@ async def tg_run_add_member_batch(batch_id: str, max_actions: int = 100) -> dict
             batch["run_lock_until_ts"] = now
             state[batch["id"]] = batch
             _save_batches_state(state)
-            return _blocked("batch is not approved; call tg_approve_batch first", **_summarize_batch(batch))
+            return _blocked(
+                "batch is not approved; call tg_approve_batch first",
+                **_summarize_batch(batch),
+            )
 
         approved_until_ts = int(batch.get("approved_until_ts") or 0)
         if approved_until_ts <= now:
@@ -1144,14 +2264,21 @@ async def tg_run_add_member_batch(batch_id: str, max_actions: int = 100) -> dict
             batch["run_lock_until_ts"] = now
             state[batch["id"]] = batch
             _save_batches_state(state)
-            return _blocked("batch approval expired; call tg_approve_batch again", **_summarize_batch(batch))
+            return _blocked(
+                "batch approval expired; call tg_approve_batch again",
+                **_summarize_batch(batch),
+            )
 
         if batch.get("status") == "completed":
             batch["run_lock_owner"] = None
             batch["run_lock_until_ts"] = now
             state[batch["id"]] = batch
             _save_batches_state(state)
-            return {"success": True, "message": "batch already completed", **_summarize_batch(batch)}
+            return {
+                "success": True,
+                "message": "batch already completed",
+                **_summarize_batch(batch),
+            }
 
         manager = await ctx.get_manager()
         processed_now = 0
@@ -1175,7 +2302,9 @@ async def tg_run_add_member_batch(batch_id: str, max_actions: int = 100) -> dict
                 processed_now += 1
                 continue
 
-            result = await manager.add_member_to_group(group, batch.get("user"), dry_run=False)
+            result = await manager.add_member_to_group(
+                group, batch.get("user"), dry_run=False
+            )
             action["attempts"] = int(action.get("attempts", 0)) + 1
             action["last_run_ts"] = now
 
@@ -1205,7 +2334,9 @@ async def tg_run_add_member_batch(batch_id: str, max_actions: int = 100) -> dict
                 action["status"] = "failed"
             processed_now += 1
 
-        pending_left = any(a.get("status") == "pending" for a in batch.get("actions", []))
+        pending_left = any(
+            a.get("status") == "pending" for a in batch.get("actions", [])
+        )
         if batch.get("status") == "running":
             batch["status"] = "approved" if pending_left else "completed"
         if batch.get("status") == "completed":
@@ -1240,7 +2371,9 @@ async def tg_get_actions_policy() -> dict[str, Any]:
         "idempotency_enabled": IDEMPOTENCY_ENABLED,
         "idempotency_window_sec": IDEMPOTENCY_WINDOW_SEC,
         "require_confirmation_text": REQUIRE_CONFIRMATION_TEXT,
-        "confirmation_phrase": CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None,
+        "confirmation_phrase": (
+            CONFIRMATION_PHRASE if REQUIRE_CONFIRMATION_TEXT else None
+        ),
         "min_confirmation_text_len": MIN_CONFIRMATION_TEXT_LEN,
         "require_approval_code": REQUIRE_APPROVAL_CODE,
         "approval_ttl_sec": APPROVAL_TTL_SEC if REQUIRE_APPROVAL_CODE else None,
@@ -1253,8 +2386,12 @@ async def tg_get_actions_policy() -> dict[str, Any]:
         "unsafe_policy_issues": UNSAFE_POLICY_ISSUES,
         "safe_startup_block_reason": SAFE_STARTUP_BLOCK_REASON,
         "write_context": os.environ.get("TG_WRITE_CONTEXT"),
-        "direct_telethon_write_guard": os.environ.get("TG_BLOCK_DIRECT_TELETHON_WRITE", "1") == "1",
-        "enforce_action_process": os.environ.get("TG_ENFORCE_ACTION_PROCESS", "1") == "1",
+        "direct_telethon_write_guard": os.environ.get(
+            "TG_BLOCK_DIRECT_TELETHON_WRITE", "1"
+        )
+        == "1",
+        "enforce_action_process": os.environ.get("TG_ENFORCE_ACTION_PROCESS", "1")
+        == "1",
         "group_msg_usage": limiter_stats.get("group_msg_usage"),
         "circuit_breaker": limiter_stats.get("circuit_breaker"),
         "destructive_actions_require_confirm": True,
@@ -1269,9 +2406,11 @@ async def tg_get_actions_policy() -> dict[str, Any]:
             "4) Handle duplicate_blocked by waiting or using force_resend=true intentionally.",
         ],
         "recommended_batch_flow": [
-            "1) tg_create_add_member_batch(user, groups).",
+            "1) Create a batch: tg_create_add_member_batch, "
+            "tg_create_delete_messages_batch_from_manifest, "
+            "or tg_create_leave_dialog_batch_from_candidates.",
             "2) tg_approve_batch(batch_id, confirmation_text).",
-            "3) Repeat tg_run_add_member_batch(batch_id, max_actions) until completed.",
+            "3) Repeat the matching run tool until completed.",
             "4) If lease expires, re-run tg_approve_batch and continue.",
         ],
     }

--- a/tganalytics/mcp_server_read.py
+++ b/tganalytics/mcp_server_read.py
@@ -17,11 +17,11 @@ os.environ.setdefault("TG_WRITE_CONTEXT", "read_mcp")
 os.environ.setdefault("TG_ACTION_PROCESS", "0")
 os.environ.setdefault("TG_SESSION_RUNTIME_MODE", "copy")
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+from mcp_server_common import MCPServerContext  # noqa: E402
 
-from mcp_server_common import MCPServerContext
-from tganalytics.infra.limiter import get_rate_limiter, safe_call
-from tganalytics.infra.metrics import snapshot
+from tganalytics.infra.limiter import get_rate_limiter, safe_call  # noqa: E402
+from tganalytics.infra.metrics import snapshot  # noqa: E402
 
 SERVER_NAME = os.environ.get("TG_MCP_SERVER_NAME", "tganalytics-read")
 ALLOW_SESSION_SWITCH = os.environ.get("TG_ALLOW_SESSION_SWITCH", "1") == "1"
@@ -44,7 +44,7 @@ async def tg_use_session(session_name: str) -> dict:
 
 @mcp.tool()
 async def tg_get_group_info(group: str) -> dict:
-    """Get info about a Telegram group/channel (id, title, participants_count, type)."""
+    """Get info about a Telegram dialog target (group/channel/direct chat)."""
     manager = await ctx.get_manager()
     result = await manager.get_group_info(group)
     return result or {"error": "Group not found"}
@@ -68,15 +68,25 @@ async def tg_search_participants(group: str, query: str, limit: int = 50) -> dic
 
 @mcp.tool()
 async def tg_get_messages(group: str, limit: int = 100, min_id: int = 0) -> dict:
-    """Get messages from a Telegram group (id, date, text, from_id, views, ...)."""
+    """Get messages from a Telegram dialog target (group/channel/direct chat)."""
     manager = await ctx.get_manager()
     messages = await manager.get_messages(group, limit=limit, min_id=min_id)
     return {"count": len(messages), "messages": messages}
 
 
 @mcp.tool()
+async def tg_get_messages_since(group: str, cutoff_iso: str, limit: int = 0) -> dict:
+    """Get messages from newest to oldest until cutoff_iso (YYYY-MM-DD or ISO datetime)."""
+    manager = await ctx.get_manager()
+    messages = await manager.get_messages_since(
+        group, cutoff_iso=cutoff_iso, limit=limit
+    )
+    return {"count": len(messages), "messages": messages, "cutoff_iso": cutoff_iso}
+
+
+@mcp.tool()
 async def tg_get_message_count(group: str) -> dict:
-    """Get total number of messages in a Telegram group."""
+    """Get total number of messages in a Telegram dialog target."""
     manager = await ctx.get_manager()
     count = await manager.get_message_count(group)
     if count is not None:
@@ -86,7 +96,7 @@ async def tg_get_message_count(group: str) -> dict:
 
 @mcp.tool()
 async def tg_get_group_creation_date(group: str) -> dict:
-    """Get approximate creation date of a Telegram group (via first message)."""
+    """Get approximate creation date of a Telegram dialog target (via first message)."""
     manager = await ctx.get_manager()
     dt = await manager.get_group_creation_date(group)
     if dt is not None:
@@ -130,7 +140,9 @@ async def tg_get_user_by_id(user_id: int) -> dict:
 
 
 @mcp.tool()
-async def tg_download_media(group: str, message_id: int, output_dir: str = "data/downloads") -> dict:
+async def tg_download_media(
+    group: str, message_id: int, output_dir: str = "data/downloads"
+) -> dict:
     """Download a file/media from a Telegram message to a local directory."""
     manager = await ctx.get_manager()
     path = await manager.download_media(group, message_id, output_dir)

--- a/tganalytics/tganalytics/domain/groups.py
+++ b/tganalytics/tganalytics/domain/groups.py
@@ -1,11 +1,16 @@
+import logging
 import os
 from datetime import datetime
-from typing import List, Optional, Dict, Any, Union
+from typing import Any, Dict, List, Optional, Union
+
 from telethon import TelegramClient
-from telethon.tl.types import User, Channel, Chat
 from telethon.errors import ChatAdminRequiredError, FloodWaitError
-from telethon.errors.rpcerrorlist import UserAlreadyParticipantError, UserNotParticipantError
-import logging
+from telethon.errors.rpcerrorlist import (
+    UserAlreadyParticipantError,
+    UserNotParticipantError,
+)
+from telethon.tl.types import Channel, Chat, User
+
 from tganalytics.infra.limiter import safe_call, smart_pause
 
 # Настройка логирования
@@ -29,61 +34,156 @@ def _validate_group_identifier(group_identifier: str) -> tuple[bool, str]:
 
     # Строковый числовой ID (например "-1001234567890")
     if isinstance(group_identifier, str):
-        stripped = group_identifier.lstrip('-')
+        stripped = group_identifier.lstrip("-")
         if stripped.isdigit():
             return True, ""
 
-    # Username не может содержать пробелы
-    if ' ' in group_identifier:
-        return False, f"Invalid group identifier '{group_identifier}': contains spaces. Use numeric ID or valid username without spaces."
+        # Username не может содержать пробелы
+        if " " in group_identifier:
+            return (
+                False,
+                f"Invalid group identifier '{group_identifier}': contains spaces. "
+                "Use numeric ID or valid username without spaces.",
+            )
 
     # Username должен быть 5-32 символа, только a-z, 0-9, _
-    clean_username = group_identifier.lstrip('@')
+    clean_username = group_identifier.lstrip("@")
     if len(clean_username) < 5:
-        return False, f"Invalid username '{group_identifier}': too short (min 5 characters)"
+        return (
+            False,
+            f"Invalid username '{group_identifier}': too short (min 5 characters)",
+        )
     if len(clean_username) > 32:
-        return False, f"Invalid username '{group_identifier}': too long (max 32 characters)"
+        return (
+            False,
+            f"Invalid username '{group_identifier}': too long (max 32 characters)",
+        )
 
     # Проверяем допустимые символы
     import re
-    if not re.match(r'^[a-zA-Z][a-zA-Z0-9_]*$', clean_username):
-        return False, f"Invalid username '{group_identifier}': must start with letter and contain only a-z, 0-9, _"
+
+    if not re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", clean_username):
+        return (
+            False,
+            f"Invalid username '{group_identifier}': must start with letter "
+            "and contain only a-z, 0-9, _",
+        )
 
     return True, ""
+
 
 # Проверяем тестовое окружение
 def _is_testing_environment():
     """Определяет тестовое окружение"""
     import sys
-    return (
-        os.getenv("TG_DISABLE_RATE_LIMIT_FOR_TESTS", "1") == "1"
-        and (
-            'pytest' in sys.modules
-            or 'unittest' in sys.modules
-            or os.getenv('PYTEST_CURRENT_TEST') is not None
-        )
+
+    return os.getenv("TG_DISABLE_RATE_LIMIT_FOR_TESTS", "1") == "1" and (
+        "pytest" in sys.modules
+        or "unittest" in sys.modules
+        or os.getenv("PYTEST_CURRENT_TEST") is not None
     )
+
 
 async def _safe_api_call(func, *args, operation_type: str = "api", **kwargs):
     """Helper для условного использования safe_call в зависимости от окружения"""
     if _is_testing_environment():
         # В тестах используем прямые вызовы для совместимости с моками
-        logger.debug(f"[TEST] Calling {func.__name__ if hasattr(func, '__name__') else 'function'} directly")
+        logger.debug(
+            f"[TEST] Calling {func.__name__ if hasattr(func, '__name__') else 'function'} directly"
+        )
         return await func(*args, **kwargs)
     else:
         # В продакшене используем safe_call для анти-спам защиты
-        logger.debug(f"[PROD] Calling {func.__name__ if hasattr(func, '__name__') else 'function'} via safe_call")
+        func_name = func.__name__ if hasattr(func, "__name__") else "function"
+        logger.debug(f"[PROD] Calling {func_name} via safe_call")
         return await safe_call(func, operation_type=operation_type, *args, **kwargs)
+
 
 class GroupManager:
     """Менеджер для работы с группами Telegram"""
-    
+
     def __init__(self, client: TelegramClient):
         self.client = client
 
-    async def _group_info_from_entity(self, entity: Union[Channel, Chat]) -> Dict[str, Any]:
+    @staticmethod
+    def _dialog_title(entity: Union[Channel, Chat, User]) -> str:
+        """Нормализованное отображаемое имя диалога для group/user targets."""
+        if isinstance(entity, (Channel, Chat)):
+            return getattr(entity, "title", "") or ""
+
+        full_name = " ".join(
+            part.strip()
+            for part in [
+                getattr(entity, "first_name", None),
+                getattr(entity, "last_name", None),
+            ]
+            if part
+        ).strip()
+        return (
+            full_name
+            or getattr(entity, "username", None)
+            or str(getattr(entity, "id", ""))
+        )
+
+    async def _resolve_read_entity(
+        self,
+        group_identifier: Union[str, int],
+        allow_users: bool = False,
+    ) -> Optional[Union[Channel, Chat, User]]:
+        """Resolve a readable dialog target for history/info operations.
+
+        Supports numeric IDs, usernames, and exact dialog titles with spaces.
+        """
+        is_valid, error_msg = _validate_group_identifier(group_identifier)
+        if not is_valid:
+            if isinstance(group_identifier, str) and " " in group_identifier:
+                by_title = await self._resolve_dialog_entity_by_title(
+                    group_identifier,
+                    allow_users=allow_users,
+                )
+                if by_title:
+                    return by_title
+            logger.error(f"Validation failed: {error_msg}")
+            return None
+
+        try:
+            if isinstance(group_identifier, int):
+                entity_id: Union[str, int] = group_identifier
+            elif isinstance(group_identifier, str) and (
+                group_identifier.startswith("-") and group_identifier[1:].isdigit()
+            ):
+                entity_id = int(group_identifier)
+            else:
+                entity_id = (
+                    group_identifier
+                    if group_identifier.startswith("@")
+                    else "@" + group_identifier
+                )
+
+            entity = await _safe_api_call(self.client.get_entity, entity_id)
+            if isinstance(entity, (Channel, Chat)) or (
+                allow_users and isinstance(entity, User)
+            ):
+                return entity
+        except Exception as e:
+            logger.error(f"Ошибка при разрешении группы {group_identifier}: {e}")
+
+        return None
+
+    async def _resolve_group_entity(
+        self, group_identifier: Union[str, int]
+    ) -> Optional[Union[Channel, Chat]]:
+        """Resolve a group/channel identifier for group-only operations."""
+        entity = await self._resolve_read_entity(group_identifier, allow_users=False)
+        if isinstance(entity, (Channel, Chat)):
+            return entity
+        return None
+
+    async def _group_info_from_entity(
+        self, entity: Union[Channel, Chat]
+    ) -> Dict[str, Any]:
         """Build normalized group info payload from Telegram entity."""
-        participants_count = getattr(entity, 'participants_count', None)
+        participants_count = getattr(entity, "participants_count", None)
 
         # Если participants_count отсутствует или равен 0, пытаемся получить более точное число
         if participants_count is None or participants_count == 0:
@@ -93,31 +193,63 @@ class GroupManager:
                     if isinstance(entity, Channel):
                         from telethon.tl.functions.channels import GetFullChannelRequest
 
-                        full_info = await self.client(GetFullChannelRequest(entity))
-                        return getattr(full_info.full_chat, 'participants_count', None)
+                        full_info = await _safe_api_call(
+                            self.client,
+                            GetFullChannelRequest(entity),
+                            operation_type="api",
+                        )
+                        return getattr(full_info.full_chat, "participants_count", None)
 
                     from telethon.tl.functions.messages import GetFullChatRequest
 
-                    full_info = await self.client(GetFullChatRequest(entity.id))
-                    return getattr(full_info.full_chat, 'participants_count', None)
+                    full_info = await _safe_api_call(
+                        self.client,
+                        GetFullChatRequest(entity.id),
+                        operation_type="api",
+                    )
+                    return getattr(full_info.full_chat, "participants_count", None)
 
                 full_participants_count = await _safe_api_call(get_full_info)
                 if full_participants_count is not None:
                     participants_count = full_participants_count
             except Exception as e:
-                logger.debug(f"Не удалось получить полную информацию о группе {entity.id}: {e}")
+                logger.debug(
+                    f"Не удалось получить полную информацию о группе {entity.id}: {e}"
+                )
 
         return {
-            'id': entity.id,
-            'title': entity.title,
-            'username': getattr(entity, 'username', None),
-            'participants_count': participants_count,
-            'type': 'channel' if isinstance(entity, Channel) else 'group'
+            "id": entity.id,
+            "title": entity.title,
+            "username": getattr(entity, "username", None),
+            "participants_count": participants_count,
+            "type": "channel" if isinstance(entity, Channel) else "group",
         }
 
-    async def _resolve_dialog_entity_by_title(self, group_title: str) -> Optional[Union[Channel, Chat]]:
+    async def _read_info_from_entity(
+        self, entity: Union[Channel, Chat, User]
+    ) -> Dict[str, Any]:
+        """Build normalized read/info payload for groups, channels, and direct dialogs."""
+        if isinstance(entity, User):
+            return {
+                "id": entity.id,
+                "title": self._dialog_title(entity),
+                "username": entity.username,
+                "participants_count": None,
+                "type": "user",
+                "first_name": entity.first_name,
+                "last_name": entity.last_name,
+                "is_bot": entity.bot,
+                "is_premium": getattr(entity, "premium", False),
+            }
+        return await self._group_info_from_entity(entity)
+
+    async def _resolve_dialog_entity_by_title(
+        self,
+        group_title: str,
+        allow_users: bool = False,
+    ) -> Optional[Union[Channel, Chat, User]]:
         """
-        Resolve a group by exact dialog title (case-insensitive).
+        Resolve a dialog by exact title (case-insensitive).
 
         Useful for UX where users provide "chat title" instead of @username/ID.
         """
@@ -125,11 +257,22 @@ class GroupManager:
         if not target:
             return None
 
+        allowed_types = (Channel, Chat, User) if allow_users else (Channel, Chat)
+
         async def iter_dialogs():
             async for dialog in self.client.iter_dialogs(limit=300):
                 entity = getattr(dialog, "entity", None)
-                title = (getattr(entity, "title", None) or "").strip().lower()
-                if title == target and isinstance(entity, (Channel, Chat)):
+                title = (
+                    (
+                        getattr(dialog, "title", None)
+                        or getattr(dialog, "name", None)
+                        or (self._dialog_title(entity) if entity else None)
+                        or ""
+                    )
+                    .strip()
+                    .lower()
+                )
+                if title == target and isinstance(entity, allowed_types):
                     return entity
             return None
 
@@ -138,7 +281,7 @@ class GroupManager:
         except Exception as e:
             logger.debug(f"Не удалось резолвить группу по title '{group_title}': {e}")
             return None
-    
+
     async def get_group_info(self, group_identifier: str) -> Optional[Dict[str, Any]]:
         """
         Получает информацию о группе
@@ -149,39 +292,14 @@ class GroupManager:
         Returns:
             Словарь с информацией о группе или None
         """
-        # Быстрая валидация перед API вызовом
-        is_valid, error_msg = _validate_group_identifier(group_identifier)
-        if not is_valid:
-            # UX fallback: allow group title input with spaces (e.g. "attia project").
-            if isinstance(group_identifier, str) and " " in group_identifier:
-                by_title = await self._resolve_dialog_entity_by_title(group_identifier)
-                if by_title:
-                    return await self._group_info_from_entity(by_title)
-            logger.error(f"Validation failed: {error_msg}")
-            return None
+        entity = await self._resolve_read_entity(group_identifier, allow_users=True)
+        if entity:
+            return await self._read_info_from_entity(entity)
+        return None
 
-        try:
-            # Проверяем тип идентификатора
-            if isinstance(group_identifier, int):
-                # Это числовой ID группы
-                entity = await _safe_api_call(self.client.get_entity, group_identifier)
-            elif isinstance(group_identifier, str) and (group_identifier.startswith('-') and group_identifier[1:].isdigit()):
-                # Это строковый ID группы
-                entity = await _safe_api_call(self.client.get_entity, int(group_identifier))
-            else:
-                # Это username, добавляем @ если нужно
-                if not group_identifier.startswith('@'):
-                    group_identifier = '@' + group_identifier
-                entity = await _safe_api_call(self.client.get_entity, group_identifier)
-            
-            if isinstance(entity, (Channel, Chat)):
-                return await self._group_info_from_entity(entity)
-            
-        except Exception as e:
-            logger.error(f"Ошибка при получении информации о группе {group_identifier}: {e}")
-            return None
-    
-    async def get_participants(self, group_identifier: str, limit: int = 100) -> List[Dict[str, Any]]:
+    async def get_participants(
+        self, group_identifier: str, limit: int = 100
+    ) -> List[Dict[str, Any]]:
         """
         Получает список участников группы
 
@@ -192,78 +310,72 @@ class GroupManager:
         Returns:
             Список словарей с информацией об участниках
         """
-        # Быстрая валидация
-        is_valid, error_msg = _validate_group_identifier(group_identifier)
-        if not is_valid:
-            logger.error(f"Validation failed: {error_msg}")
-            return []
-
         participants = []
 
         try:
-            # Получаем информацию о группе
-            group_info = await self.get_group_info(group_identifier)
-            if not group_info:
+            entity = await self._resolve_group_entity(group_identifier)
+            if not entity:
                 logger.error(f"Не удалось найти группу: {group_identifier}")
                 return []
-            
+
+            group_info = await self._group_info_from_entity(entity)
             logger.info(f"Получаем участников группы: {group_info['title']}")
-            
-            # Определяем идентификатор для iter_participants
-            if isinstance(group_identifier, int):
-                group_id = group_identifier
-            elif isinstance(group_identifier, str) and (group_identifier.startswith('-') and group_identifier[1:].isdigit()):
-                group_id = int(group_identifier)
-            else:
-                group_id = group_identifier if group_identifier.startswith('@') else '@' + group_identifier
-            
+
             # Получаем участников с anti-spam защитой через safe_call
             count = 0
-            
+
             # Создаем wrapper функцию для безопасного получения участников
             async def get_participants_safe():
                 users = []
-                async for user in self.client.iter_participants(group_id, limit=limit):
+                async for user in self.client.iter_participants(entity, limit=limit):
                     users.append(user)
                 return users
-            
+
             # Вызываем через safe_call для анти-спам защиты
             users = await _safe_api_call(get_participants_safe)
-            
+
             for user in users:
                 if isinstance(user, User) and not user.bot:  # Исключаем ботов
                     participant_info = {
-                        'id': user.id,
-                        'username': user.username,
-                        'first_name': user.first_name,
-                        'last_name': user.last_name,
-                        'phone': user.phone,
-                        'is_bot': user.bot,
-                        'is_verified': user.verified,
-                        'is_premium': getattr(user, 'premium', False),
-                        'status': str(user.status) if user.status else None
+                        "id": user.id,
+                        "username": user.username,
+                        "first_name": user.first_name,
+                        "last_name": user.last_name,
+                        "phone": user.phone,
+                        "is_bot": user.bot,
+                        "is_verified": user.verified,
+                        "is_premium": getattr(user, "premium", False),
+                        "status": str(user.status) if user.status else None,
                     }
                     participants.append(participant_info)
                     count += 1
-                    
+
                     # Smart pause каждые 1000 участников для предотвращения FLOOD_WAIT
                     if count % 1000 == 0:
                         await smart_pause("participants", count)
-            
-            logger.info(f"Получено {len(participants)} участников из группы {group_info['title']}")
+
+            logger.info(
+                f"Получено {len(participants)} участников из группы {group_info['title']}"
+            )
             return participants
-            
+
         except ChatAdminRequiredError:
-            logger.error(f"Нет прав администратора для получения участников группы: {group_identifier}")
+            logger.error(
+                f"Нет прав администратора для получения участников группы: {group_identifier}"
+            )
             return []
         except FloodWaitError as e:
             logger.error(f"Превышен лимит запросов. Ожидание {e.seconds} секунд")
             return []
         except Exception as e:
-            logger.error(f"Ошибка при получении участников группы {group_identifier}: {e}")
+            logger.error(
+                f"Ошибка при получении участников группы {group_identifier}: {e}"
+            )
             return []
-    
-    async def search_participants(self, group_identifier: str, query: str, limit: int = 50) -> List[Dict[str, Any]]:
+
+    async def search_participants(
+        self, group_identifier: str, query: str, limit: int = 50
+    ) -> List[Dict[str, Any]]:
         """
         Ищет участников в группе по запросу
 
@@ -275,100 +387,108 @@ class GroupManager:
         Returns:
             Список найденных участников
         """
-        # Быстрая валидация
-        is_valid, error_msg = _validate_group_identifier(group_identifier)
-        if not is_valid:
-            logger.error(f"Validation failed: {error_msg}")
-            return []
-
         participants = []
 
         try:
-            logger.info(f"Поиск участников в группе {group_identifier} по запросу: {query}")
-            
-            # Определяем идентификатор для iter_participants
-            if isinstance(group_identifier, int):
-                group_id = group_identifier
-            elif isinstance(group_identifier, str) and (group_identifier.startswith('-') and group_identifier[1:].isdigit()):
-                group_id = int(group_identifier)
-            else:
-                group_id = group_identifier if group_identifier.startswith('@') else '@' + group_identifier
-            
+            logger.info(
+                f"Поиск участников в группе {group_identifier} по запросу: {query}"
+            )
+
+            entity = await self._resolve_group_entity(group_identifier)
+            if not entity:
+                logger.error(f"Не удалось найти группу: {group_identifier}")
+                return []
+
             # Создаем wrapper функцию для безопасного поиска участников
             async def search_participants_safe():
                 users = []
                 async for user in self.client.iter_participants(
-                    group_id, 
-                    search=query, 
-                    limit=limit
+                    entity, search=query, limit=limit
                 ):
                     users.append(user)
                 return users
-            
+
             # Вызываем через safe_call для анти-спам защиты
             users = await _safe_api_call(search_participants_safe)
-            
+
             for user in users:
                 if isinstance(user, User) and not user.bot:
                     participant_info = {
-                        'id': user.id,
-                        'username': user.username,
-                        'first_name': user.first_name,
-                        'last_name': user.last_name,
-                        'phone': user.phone,
-                        'is_bot': user.bot,
-                        'is_verified': user.verified,
-                        'is_premium': getattr(user, 'premium', False),
-                        'status': str(user.status) if user.status else None
+                        "id": user.id,
+                        "username": user.username,
+                        "first_name": user.first_name,
+                        "last_name": user.last_name,
+                        "phone": user.phone,
+                        "is_bot": user.bot,
+                        "is_verified": user.verified,
+                        "is_premium": getattr(user, "premium", False),
+                        "status": str(user.status) if user.status else None,
                     }
                     participants.append(participant_info)
-            
+
             logger.info(f"Найдено {len(participants)} участников по запросу '{query}'")
             return participants
-            
+
         except Exception as e:
             logger.error(f"Ошибка при поиске участников: {e}")
             return []
-    
-    async def export_participants_to_csv(self, group_identifier: str, filename: str, limit: int = 1000) -> bool:
+
+    async def export_participants_to_csv(
+        self, group_identifier: str, filename: str, limit: int = 1000
+    ) -> bool:
         """
         Экспортирует список участников в CSV файл
-        
+
         Args:
             group_identifier: username группы (без @) или ID группы
             filename: имя файла для сохранения
             limit: максимальное количество участников
-            
+
         Returns:
             True если экспорт успешен, False в противном случае
         """
         import csv
-        
+
         try:
             participants = await self.get_participants(group_identifier, limit)
-            
+
             if not participants:
                 logger.warning("Нет участников для экспорта")
                 return False
-            
-            with open(filename, 'w', newline='', encoding='utf-8') as csvfile:
-                fieldnames = ['id', 'username', 'first_name', 'last_name', 'phone', 'is_verified', 'is_premium', 'status']
+
+            with open(filename, "w", newline="", encoding="utf-8") as csvfile:
+                fieldnames = [
+                    "id",
+                    "username",
+                    "first_name",
+                    "last_name",
+                    "phone",
+                    "is_verified",
+                    "is_premium",
+                    "status",
+                ]
                 writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-                
+
                 writer.writeheader()
                 for participant in participants:
                     # Очищаем данные для CSV
-                    clean_participant = {k: v for k, v in participant.items() if k in fieldnames}
+                    clean_participant = {
+                        k: v for k, v in participant.items() if k in fieldnames
+                    }
                     writer.writerow(clean_participant)
-            
-            logger.info(f"Экспортировано {len(participants)} участников в файл {filename}")
+
+            logger.info(
+                f"Экспортировано {len(participants)} участников в файл {filename}"
+            )
             return True
-            
+
         except Exception as e:
             logger.error(f"Ошибка при экспорте в CSV: {e}")
             return False
-    
-    async def get_group_creation_date(self, group_identifier: Union[str, int]) -> Optional[datetime]:
+
+    async def get_group_creation_date(
+        self, group_identifier: Union[str, int]
+    ) -> Optional[datetime]:
         """
         Получает приблизительную дату создания группы через первое сообщение
 
@@ -381,75 +501,60 @@ class GroupManager:
         Returns:
             datetime объект с датой создания или None при ошибке
         """
-        # Быстрая валидация
-        is_valid, error_msg = _validate_group_identifier(group_identifier)
-        if not is_valid:
-            logger.error(f"Validation failed: {error_msg}")
-            return None
-
         try:
-            # Нормализуем идентификатор группы (как в других методах)
-            if isinstance(group_identifier, int):
-                # Это числовой ID группы - используем как есть
-                entity_id = group_identifier
-            elif isinstance(group_identifier, str) and (group_identifier.startswith('-') and group_identifier[1:].isdigit()):
-                # Это строковый ID группы - конвертируем в int
-                entity_id = int(group_identifier)
-            else:
-                # Это username - добавляем @ если нужно
-                if not group_identifier.startswith('@'):
-                    entity_id = '@' + group_identifier
-                else:
-                    entity_id = group_identifier
-            
+            entity = await self._resolve_read_entity(group_identifier, allow_users=True)
+            if not entity:
+                logger.error(f"Не удалось найти группу: {group_identifier}")
+                return None
+
             # Функция для получения первого сообщения
             async def get_first_message():
-                async for msg in self.client.iter_messages(entity_id, reverse=True, limit=1):
+                async for msg in self.client.iter_messages(
+                    entity, reverse=True, limit=1
+                ):
                     return msg.date
                 return None
-            
+
             # Вызываем через safe_call для анти-спам защиты
             creation_date = await _safe_api_call(get_first_message)
-            
+
             if creation_date:
-                logger.info(f"Получена дата создания группы {group_identifier}: {creation_date}")
+                logger.info(
+                    f"Получена дата создания группы {group_identifier}: {creation_date}"
+                )
                 return creation_date
             else:
-                logger.warning(f"Не удалось получить дату создания для группы {group_identifier}")
+                logger.warning(
+                    f"Не удалось получить дату создания для группы {group_identifier}"
+                )
                 return None
-                
+
         except Exception as e:
-            logger.error(f"Ошибка при получении даты создания группы {group_identifier}: {e}")
+            logger.error(
+                f"Ошибка при получении даты создания группы {group_identifier}: {e}"
+            )
             return None
 
-    async def get_message_count(self, group_identifier: Union[str, int]) -> Optional[int]:
+    async def get_message_count(
+        self, group_identifier: Union[str, int]
+    ) -> Optional[int]:
         """
         Быстро получает количество сообщений в чате/группе (если доступно).
 
         Использует `messages.GetHistoryRequest(limit=0)`, что обычно возвращает `count`
         без выгрузки истории.
         """
-        # Быстрая валидация
-        is_valid, error_msg = _validate_group_identifier(group_identifier)
-        if not is_valid:
-            logger.error(f"Validation failed: {error_msg}")
-            return None
-
         try:
-            # normalize identifier
-            if isinstance(group_identifier, int):
-                entity_id: Union[str, int] = group_identifier
-            elif isinstance(group_identifier, str) and (group_identifier.startswith("-") and group_identifier[1:].isdigit()):
-                entity_id = int(group_identifier)
-            else:
-                entity_id = group_identifier if str(group_identifier).startswith("@") else "@" + str(group_identifier)
-
-            entity = await _safe_api_call(self.client.get_entity, entity_id)
+            entity = await self._resolve_read_entity(group_identifier, allow_users=True)
+            if not entity:
+                logger.error(f"Не удалось найти группу: {group_identifier}")
+                return None
 
             async def get_count():
                 from telethon.tl.functions.messages import GetHistoryRequest
 
-                hist = await self.client(
+                hist = await _safe_api_call(
+                    self.client,
                     GetHistoryRequest(
                         peer=entity,
                         limit=0,
@@ -459,16 +564,24 @@ class GroupManager:
                         min_id=0,
                         add_offset=0,
                         hash=0,
-                    )
+                    ),
+                    operation_type="api",
                 )
                 return getattr(hist, "count", None)
 
             return await _safe_api_call(get_count)
         except Exception as e:
-            logger.debug(f"Не удалось получить messages count для {group_identifier}: {e}")
+            logger.debug(
+                f"Не удалось получить messages count для {group_identifier}: {e}"
+            )
             return None
-    
-    async def get_messages(self, group_identifier: Union[str, int], limit: Optional[int] = None, min_id: int = 0) -> List[Dict[str, Any]]:
+
+    async def get_messages(
+        self,
+        group_identifier: Union[str, int],
+        limit: Optional[int] = None,
+        min_id: int = 0,
+    ) -> List[Dict[str, Any]]:
         """
         Получает сообщения группы с антиспам защитой
 
@@ -480,115 +593,250 @@ class GroupManager:
         Returns:
             Список словарей с информацией о сообщениях
         """
-        # Быстрая валидация
-        is_valid, error_msg = _validate_group_identifier(group_identifier)
-        if not is_valid:
-            logger.error(f"Validation failed: {error_msg}")
-            return []
-
         try:
-            # Нормализуем идентификатор группы
-            if isinstance(group_identifier, int):
-                entity_id = group_identifier
-            elif isinstance(group_identifier, str) and (group_identifier.startswith('-') and group_identifier[1:].isdigit()):
-                entity_id = int(group_identifier)
-            else:
-                if not group_identifier.startswith('@'):
-                    entity_id = '@' + group_identifier
-                else:
-                    entity_id = group_identifier
-            
-            # Получаем entity
-            entity = await _safe_api_call(self.client.get_entity, entity_id)
-            
+            entity = await self._resolve_read_entity(group_identifier, allow_users=True)
+            if not entity:
+                logger.error(f"Не удалось найти группу: {group_identifier}")
+                return []
+
             # Функция для безопасного получения сообщений
             async def fetch_messages_safe():
                 messages = []
                 count = 0
-                
+
                 async for msg in self.client.iter_messages(
                     entity,
                     limit=limit,
                     min_id=min_id,
-                    reverse=False  # От старых к новым
+                    reverse=False,  # От старых к новым
                 ):
                     # Пропускаем служебные сообщения
                     if not msg.message and not msg.media:
                         continue
-                    
+
                     # Extract fwd_from info
                     fwd_from = None
                     if msg.fwd_from:
                         fwd = msg.fwd_from
                         fwd_from = {
-                            'from_id': None,
-                            'from_type': None,
-                            'from_name': fwd.from_name,
-                            'from_username': None,
-                            'from_first_name': None,
-                            'from_last_name': None,
-                            'date': fwd.date.isoformat() if fwd.date else None,
-                            'channel_post': fwd.channel_post,
+                            "from_id": None,
+                            "from_type": None,
+                            "from_name": fwd.from_name,
+                            "from_username": None,
+                            "from_first_name": None,
+                            "from_last_name": None,
+                            "date": fwd.date.isoformat() if fwd.date else None,
+                            "channel_post": fwd.channel_post,
                         }
                         if fwd.from_id:
-                            from telethon.tl.types import PeerUser, PeerChannel, PeerChat
+                            from telethon.tl.types import (
+                                PeerChannel,
+                                PeerChat,
+                                PeerUser,
+                            )
+
                             if isinstance(fwd.from_id, PeerUser):
-                                fwd_from['from_id'] = fwd.from_id.user_id
-                                fwd_from['from_type'] = 'user'
+                                fwd_from["from_id"] = fwd.from_id.user_id
+                                fwd_from["from_type"] = "user"
                             elif isinstance(fwd.from_id, PeerChannel):
-                                fwd_from['from_id'] = fwd.from_id.channel_id
-                                fwd_from['from_type'] = 'channel'
+                                fwd_from["from_id"] = fwd.from_id.channel_id
+                                fwd_from["from_type"] = "channel"
                             elif isinstance(fwd.from_id, PeerChat):
-                                fwd_from['from_id'] = fwd.from_id.chat_id
-                                fwd_from['from_type'] = 'chat'
+                                fwd_from["from_id"] = fwd.from_id.chat_id
+                                fwd_from["from_type"] = "chat"
                         # Resolve name/username from cached entities (no extra API calls)
                         # msg.forward.sender/.chat are populated from the iter_messages response
                         if msg.forward:
                             fwd_entity = msg.forward.sender or msg.forward.chat
                             if fwd_entity:
-                                fwd_from['from_username'] = getattr(fwd_entity, 'username', None)
-                                fwd_from['from_first_name'] = getattr(fwd_entity, 'first_name', None)
-                                fwd_from['from_last_name'] = getattr(fwd_entity, 'last_name', None)
+                                fwd_from["from_username"] = getattr(
+                                    fwd_entity, "username", None
+                                )
+                                fwd_from["from_first_name"] = getattr(
+                                    fwd_entity, "first_name", None
+                                )
+                                fwd_from["from_last_name"] = getattr(
+                                    fwd_entity, "last_name", None
+                                )
 
                     message_data = {
-                        'id': msg.id,
-                        'date': msg.date.isoformat() if msg.date else None,
-                        'from_id': msg.from_id.user_id if msg.from_id else None,
-                        'text': msg.message or '',
-                        'fwd_from': fwd_from,
-                        'is_reply': msg.reply_to is not None,
-                        'reply_to_msg_id': msg.reply_to.reply_to_msg_id if msg.reply_to else None,
-                        'views': getattr(msg, 'views', None),
-                        'forwards': getattr(msg, 'forwards', None),
-                        'is_pinned': getattr(msg, 'is_pinned', False),
-                        'has_media': msg.media is not None,
-                        'media_type': type(msg.media).__name__ if msg.media else None,
+                        "id": msg.id,
+                        "date": msg.date.isoformat() if msg.date else None,
+                        "from_id": msg.from_id.user_id if msg.from_id else None,
+                        "text": msg.message or "",
+                        "fwd_from": fwd_from,
+                        "is_reply": msg.reply_to is not None,
+                        "reply_to_msg_id": (
+                            msg.reply_to.reply_to_msg_id if msg.reply_to else None
+                        ),
+                        "views": getattr(msg, "views", None),
+                        "forwards": getattr(msg, "forwards", None),
+                        "is_pinned": getattr(msg, "is_pinned", False),
+                        "has_media": msg.media is not None,
+                        "media_type": type(msg.media).__name__ if msg.media else None,
                     }
-                    
+
                     messages.append(message_data)
                     count += 1
-                    
+
                     # Smart pause каждые 1000 сообщений
                     if count % 1000 == 0:
                         await smart_pause("participants", count)
-                    
+
                     # Проверка лимита
                     if limit and count >= limit:
                         break
-                
+
                 return messages
-            
+
             # Вызываем через safe_call для анти-спам защиты
             messages = await _safe_api_call(fetch_messages_safe)
-            
-            logger.info(f"Получено {len(messages)} сообщений из группы {group_identifier}")
+
+            logger.info(
+                f"Получено {len(messages)} сообщений из группы {group_identifier}"
+            )
             return messages
-            
+
         except Exception as e:
-            logger.error(f"Ошибка при получении сообщений группы {group_identifier}: {e}")
+            logger.error(
+                f"Ошибка при получении сообщений группы {group_identifier}: {e}"
+            )
             return []
-    
-    async def get_my_dialogs(self, limit: int = 100, dialog_type: str = "all") -> List[Dict[str, Any]]:
+
+    @staticmethod
+    def _parse_cutoff_datetime(cutoff_iso: str) -> Optional[datetime]:
+        raw = str(cutoff_iso or "").strip()
+        if not raw:
+            return None
+        try:
+            if raw.endswith("Z"):
+                raw = raw[:-1] + "+00:00"
+            if len(raw) == 10:
+                return datetime.fromisoformat(raw)
+            return datetime.fromisoformat(raw).replace(tzinfo=None)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _media_metadata(msg) -> Dict[str, Any]:
+        file_obj = getattr(msg, "file", None)
+        return {
+            "media_mime_type": getattr(file_obj, "mime_type", None),
+            "media_filename": getattr(file_obj, "name", None),
+            "media_size": getattr(file_obj, "size", None),
+        }
+
+    @classmethod
+    def _message_to_record(cls, msg) -> Dict[str, Any]:
+        fwd_from = None
+        if getattr(msg, "fwd_from", None):
+            fwd = msg.fwd_from
+            fwd_from = {
+                "from_id": None,
+                "from_type": None,
+                "from_name": fwd.from_name,
+                "from_username": None,
+                "from_first_name": None,
+                "from_last_name": None,
+                "date": fwd.date.isoformat() if fwd.date else None,
+                "channel_post": fwd.channel_post,
+            }
+            if fwd.from_id:
+                from telethon.tl.types import PeerChannel, PeerChat, PeerUser
+
+                if isinstance(fwd.from_id, PeerUser):
+                    fwd_from["from_id"] = fwd.from_id.user_id
+                    fwd_from["from_type"] = "user"
+                elif isinstance(fwd.from_id, PeerChannel):
+                    fwd_from["from_id"] = fwd.from_id.channel_id
+                    fwd_from["from_type"] = "channel"
+                elif isinstance(fwd.from_id, PeerChat):
+                    fwd_from["from_id"] = fwd.from_id.chat_id
+            if getattr(msg, "forward", None):
+                fwd_entity = msg.forward.sender or msg.forward.chat
+                if fwd_entity:
+                    fwd_from["from_username"] = getattr(fwd_entity, "username", None)
+                    fwd_from["from_first_name"] = getattr(
+                        fwd_entity, "first_name", None
+                    )
+                    fwd_from["from_last_name"] = getattr(fwd_entity, "last_name", None)
+
+        record = {
+            "id": msg.id,
+            "date": msg.date.isoformat() if msg.date else None,
+            "from_id": msg.from_id.user_id if msg.from_id else None,
+            "text": msg.message or "",
+            "caption": msg.message or "",
+            "fwd_from": fwd_from,
+            "is_reply": msg.reply_to is not None,
+            "reply_to_msg_id": msg.reply_to.reply_to_msg_id if msg.reply_to else None,
+            "views": getattr(msg, "views", None),
+            "forwards": getattr(msg, "forwards", None),
+            "is_pinned": getattr(msg, "is_pinned", False),
+            "has_media": msg.media is not None,
+            "media_type": type(msg.media).__name__ if msg.media else None,
+        }
+        record.update(cls._media_metadata(msg))
+        return record
+
+    async def get_messages_since(
+        self,
+        group_identifier: Union[str, int],
+        cutoff_iso: str,
+        limit: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Read messages from newest to oldest until cutoff date is crossed."""
+        try:
+            entity = await self._resolve_read_entity(group_identifier, allow_users=True)
+            if not entity:
+                logger.error(f"Не удалось найти группу: {group_identifier}")
+                return []
+
+            cutoff_dt = self._parse_cutoff_datetime(cutoff_iso)
+            if cutoff_dt is None:
+                raise ValueError(f"Invalid cutoff_iso: {cutoff_iso!r}")
+            normalized_limit = int(limit or 0)
+            if normalized_limit < 0:
+                raise ValueError("limit must be >= 0")
+
+            async def fetch_messages_safe():
+                messages = []
+                count = 0
+                iter_limit = normalized_limit if normalized_limit > 0 else None
+                async for msg in self.client.iter_messages(
+                    entity, limit=iter_limit, reverse=False
+                ):
+                    msg_dt = msg.date
+                    if msg_dt is not None:
+                        msg_naive = msg_dt.replace(tzinfo=None)
+                        if msg_naive < cutoff_dt:
+                            break
+
+                    if not msg.message and not msg.media:
+                        continue
+
+                    messages.append(self._message_to_record(msg))
+                    count += 1
+                    if count % 1000 == 0:
+                        await smart_pause("participants", count)
+                    if normalized_limit and count >= normalized_limit:
+                        break
+                return messages
+
+            messages = await _safe_api_call(fetch_messages_safe)
+            logger.info(
+                f"Получено {len(messages)} сообщений из {group_identifier} после {cutoff_iso}"
+            )
+            return messages
+        except Exception as e:
+            logger.error(
+                f"Ошибка при получении сообщений since для {group_identifier}: {e}"
+            )
+            return []
+
+    async def get_my_dialogs(
+        self, limit: int = 100, dialog_type: str = "all"
+    ) -> List[Dict[str, Any]]:
         """
         Получает список диалогов (групп/каналов/личных чатов) текущего аккаунта.
 
@@ -600,6 +848,7 @@ class GroupManager:
             Список словарей с информацией о диалогах
         """
         try:
+
             async def fetch_dialogs():
                 dialogs = []
                 async for dialog in self.client.iter_dialogs(limit=limit):
@@ -622,20 +871,31 @@ class GroupManager:
                 if dialog_type != "all" and dtype != dialog_type:
                     continue
 
-                results.append({
-                    "id": dialog.id,
-                    "title": dialog.title or dialog.name or "Untitled",
-                    "type": dtype,
-                    "username": getattr(dialog.entity, "username", None),
-                    "participants_count": getattr(dialog.entity, "participants_count", None),
-                    "unread_count": dialog.unread_count,
-                })
+                results.append(
+                    {
+                        "id": dialog.id,
+                        "title": dialog.title or dialog.name or "Untitled",
+                        "type": dtype,
+                        "username": getattr(dialog.entity, "username", None),
+                        "phone": (
+                            getattr(dialog.entity, "phone", None)
+                            if dtype == "user"
+                            else None
+                        ),
+                        "participants_count": getattr(
+                            dialog.entity, "participants_count", None
+                        ),
+                        "unread_count": dialog.unread_count,
+                    }
+                )
 
             logger.info(f"Получено {len(results)} диалогов (фильтр: {dialog_type})")
             return results
 
         except FloodWaitError as e:
-            logger.error(f"Превышен лимит запросов при получении диалогов. Ожидание {e.seconds} секунд")
+            logger.error(
+                f"Превышен лимит запросов при получении диалогов. Ожидание {e.seconds} секунд"
+            )
             return []
         except Exception as e:
             logger.error(f"Ошибка при получении диалогов: {e}")
@@ -652,47 +912,49 @@ class GroupManager:
             Словарь с id, type, username, first_name, last_name и т.д., или None
         """
         try:
-            if not username.startswith('@'):
-                username = '@' + username
+            if not username.startswith("@"):
+                username = "@" + username
 
             entity = await _safe_api_call(self.client.get_entity, username)
 
             if isinstance(entity, User):
                 return {
-                    'id': entity.id,
-                    'type': 'user',
-                    'username': entity.username,
-                    'first_name': entity.first_name,
-                    'last_name': entity.last_name,
-                    'is_bot': entity.bot,
-                    'is_premium': getattr(entity, 'premium', False),
+                    "id": entity.id,
+                    "type": "user",
+                    "username": entity.username,
+                    "first_name": entity.first_name,
+                    "last_name": entity.last_name,
+                    "is_bot": entity.bot,
+                    "is_premium": getattr(entity, "premium", False),
                 }
             elif isinstance(entity, Channel):
                 return {
-                    'id': entity.id,
-                    'type': 'channel' if entity.broadcast else 'supergroup',
-                    'username': entity.username,
-                    'title': entity.title,
-                    'participants_count': getattr(entity, 'participants_count', None),
+                    "id": entity.id,
+                    "type": "channel" if entity.broadcast else "supergroup",
+                    "username": entity.username,
+                    "title": entity.title,
+                    "participants_count": getattr(entity, "participants_count", None),
                 }
             elif isinstance(entity, Chat):
                 return {
-                    'id': entity.id,
-                    'type': 'chat',
-                    'title': entity.title,
-                    'participants_count': getattr(entity, 'participants_count', None),
+                    "id": entity.id,
+                    "type": "chat",
+                    "title": entity.title,
+                    "participants_count": getattr(entity, "participants_count", None),
                 }
             else:
                 return {
-                    'id': getattr(entity, 'id', None),
-                    'type': type(entity).__name__,
+                    "id": getattr(entity, "id", None),
+                    "type": type(entity).__name__,
                 }
 
         except Exception as e:
             logger.error(f"Ошибка при resolve username {username}: {e}")
             return None
 
-    async def download_media(self, group_identifier: Union[str, int], message_id: int, output_dir: str) -> Optional[str]:
+    async def download_media(
+        self, group_identifier: Union[str, int], message_id: int, output_dir: str
+    ) -> Optional[str]:
         """
         Скачивает медиа/файл из сообщения в указанную директорию.
 
@@ -704,24 +966,11 @@ class GroupManager:
         Returns:
             Путь к скачанному файлу или None при ошибке
         """
-        # Быстрая валидация
-        is_valid, error_msg = _validate_group_identifier(group_identifier)
-        if not is_valid:
-            logger.error(f"Validation failed: {error_msg}")
-            return None
-
         try:
-            if isinstance(group_identifier, int):
-                entity_id = group_identifier
-            elif isinstance(group_identifier, str) and (group_identifier.startswith('-') and group_identifier[1:].isdigit()):
-                entity_id = int(group_identifier)
-            else:
-                if not group_identifier.startswith('@'):
-                    entity_id = '@' + group_identifier
-                else:
-                    entity_id = group_identifier
-
-            entity = await _safe_api_call(self.client.get_entity, entity_id)
+            entity = await self._resolve_read_entity(group_identifier, allow_users=True)
+            if not entity:
+                logger.error(f"Не удалось найти группу: {group_identifier}")
+                return None
 
             async def do_download():
                 msgs = await self.client.get_messages(entity, ids=message_id)
@@ -750,19 +999,104 @@ class GroupManager:
         if not raw:
             raise ValueError("User identifier is empty")
 
-        stripped = raw.lstrip('-')
+        stripped = raw.lstrip("-")
         if stripped.isdigit():
             return int(raw)
 
-        return raw if raw.startswith('@') else '@' + raw
+        return raw if raw.startswith("@") else "@" + raw
 
-    async def _resolve_group_entity_for_admin(self, group_identifier: Union[str, int]) -> Union[Channel, Chat]:
+    @staticmethod
+    def _normalize_message_ids(
+        message_ids: Union[int, List[int], tuple, set],
+    ) -> List[int]:
+        """Нормализует и дедуплицирует IDs сообщений с сохранением порядка."""
+        raw_items = (
+            [message_ids] if isinstance(message_ids, int) else list(message_ids or [])
+        )
+        normalized: List[int] = []
+        seen = set()
+        for item in raw_items:
+            try:
+                message_id = int(item)
+            except Exception as exc:
+                raise ValueError(f"Invalid message id: {item!r}") from exc
+            if message_id <= 0:
+                raise ValueError(f"Invalid message id: {message_id}")
+            if message_id in seen:
+                continue
+            seen.add(message_id)
+            normalized.append(message_id)
+        if not normalized:
+            raise ValueError("message_ids is empty")
+        return normalized
+
+    @staticmethod
+    def _entity_target(entity: Union[Channel, Chat]) -> str:
+        username = getattr(entity, "username", None)
+        if username:
+            return f"@{username}"
+        return str(getattr(entity, "id", ""))
+
+    async def _resolve_linked_discussion_group(
+        self,
+        channel_identifier: Union[str, int],
+    ) -> tuple[Channel, dict[str, Any]]:
+        channel_entity = await self._resolve_group_entity_for_admin(channel_identifier)
+        if not isinstance(channel_entity, Channel):
+            raise ValueError(
+                f"Target '{channel_identifier}' is not a channel/supergroup"
+            )
+
+        from telethon.tl.functions.channels import GetFullChannelRequest
+
+        full_info = await _safe_api_call(
+            self.client,
+            GetFullChannelRequest(channel_entity),
+            operation_type="api",
+        )
+        full_chat = getattr(full_info, "full_chat", None)
+        linked_chat_id = getattr(full_chat, "linked_chat_id", None)
+        if not linked_chat_id:
+            raise ValueError(
+                f"Channel '{channel_identifier}' has no linked discussion group"
+            )
+
+        linked_entity = None
+        for item in getattr(full_info, "chats", []) or []:
+            if getattr(item, "id", None) == linked_chat_id:
+                linked_entity = item
+                break
+
+        if linked_entity is None:
+            linked_entity = await _safe_api_call(self.client.get_entity, linked_chat_id)
+
+        if not isinstance(linked_entity, Channel):
+            raise ValueError(
+                f"Linked discussion target for '{channel_identifier}' is not a supergroup"
+            )
+
+        info = {
+            "channel_id": channel_entity.id,
+            "channel_title": getattr(channel_entity, "title", None),
+            "channel_username": getattr(channel_entity, "username", None),
+            "channel_target": self._entity_target(channel_entity),
+            "linked_group_id": linked_entity.id,
+            "linked_group_title": getattr(linked_entity, "title", None),
+            "linked_group_username": getattr(linked_entity, "username", None),
+            "linked_group_target": self._entity_target(linked_entity),
+            "current_join_required": getattr(linked_entity, "join_to_send", None),
+        }
+        return linked_entity, info
+
+    async def _resolve_group_entity_for_admin(
+        self, group_identifier: Union[str, int]
+    ) -> Union[Channel, Chat]:
         """Резолвит группу/канал для admin-операций."""
         if isinstance(group_identifier, int):
             entity_id: Union[str, int] = group_identifier
         elif (
             isinstance(group_identifier, str)
-            and group_identifier.startswith('-')
+            and group_identifier.startswith("-")
             and group_identifier[1:].isdigit()
         ):
             entity_id = int(group_identifier)
@@ -771,8 +1105,9 @@ class GroupManager:
             if not is_valid:
                 raise ValueError(error_msg)
             entity_id = (
-                str(group_identifier) if str(group_identifier).startswith('@')
-                else '@' + str(group_identifier)
+                str(group_identifier)
+                if str(group_identifier).startswith("@")
+                else "@" + str(group_identifier)
             )
 
         entity = await _safe_api_call(self.client.get_entity, entity_id)
@@ -780,13 +1115,232 @@ class GroupManager:
             raise ValueError(f"Target '{group_identifier}' is not a group/channel")
         return entity
 
-    async def _resolve_user_entity_for_admin(self, user_identifier: Union[str, int]) -> User:
+    async def _resolve_user_entity_for_admin(
+        self, user_identifier: Union[str, int]
+    ) -> User:
         """Резолвит целевого пользователя для admin-операций."""
         normalized = self._normalize_user_identifier(user_identifier)
         entity = await _safe_api_call(self.client.get_entity, normalized)
         if not isinstance(entity, User):
             raise ValueError(f"Target '{user_identifier}' is not a Telegram user")
         return entity
+
+    async def create_private_group(
+        self,
+        title: str,
+        users: Optional[List[Union[str, int]]] = None,
+        about: str = "",
+        kind: str = "basic",
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Create a private Telegram group and optionally invite users."""
+        clean_title = str(title or "").strip()
+        if not clean_title:
+            raise ValueError("Group title is empty")
+
+        group_kind = str(kind or "basic").strip().lower()
+        if group_kind not in {"basic", "supergroup"}:
+            raise ValueError("kind must be 'basic' or 'supergroup'")
+
+        invitees = list(users or [])
+        if group_kind == "basic" and not invitees:
+            raise ValueError("basic group creation requires at least one invitee")
+
+        resolved_users = []
+        user_entities = []
+        for user_identifier in invitees:
+            user_entity = await self._resolve_user_entity_for_admin(user_identifier)
+            user_entities.append(user_entity)
+            resolved_users.append(
+                {
+                    "input": str(user_identifier),
+                    "user_id": user_entity.id,
+                    "username": user_entity.username,
+                    "first_name": user_entity.first_name,
+                    "is_bot": user_entity.bot,
+                }
+            )
+
+        result: Dict[str, Any] = {
+            "success": True,
+            "action": "create_private_group",
+            "dry_run": dry_run,
+            "title": clean_title,
+            "about": str(about or ""),
+            "kind": group_kind,
+            "invitees": resolved_users,
+        }
+        if dry_run:
+            return result
+
+        invite_results = []
+        if group_kind == "basic":
+            from telethon.tl.functions.messages import CreateChatRequest
+
+            created = await _safe_api_call(
+                self.client,
+                CreateChatRequest(users=user_entities, title=clean_title),
+                operation_type="join",
+            )
+            for user_identifier, user_entity in zip(invitees, user_entities):
+                invite_results.append(
+                    {
+                        "success": True,
+                        "created_with_group": True,
+                        "user": str(user_identifier),
+                        "user_id": user_entity.id,
+                        "username": user_entity.username,
+                    }
+                )
+        else:
+            from telethon.tl.functions.channels import CreateChannelRequest
+
+            created = await _safe_api_call(
+                self.client,
+                CreateChannelRequest(
+                    title=clean_title,
+                    about=str(about or ""),
+                    megagroup=True,
+                    broadcast=False,
+                ),
+                operation_type="join",
+            )
+
+        group_entity = None
+        for chat in getattr(created, "chats", []) or []:
+            if (
+                isinstance(chat, (Channel, Chat))
+                and getattr(chat, "title", None) == clean_title
+            ):
+                group_entity = chat
+                break
+        if group_entity is None:
+            for chat in getattr(created, "chats", []) or []:
+                if isinstance(chat, (Channel, Chat)):
+                    group_entity = chat
+                    break
+        if group_entity is None:
+            group_entity = await self._resolve_dialog_entity_by_title(
+                clean_title, allow_users=False
+            )
+        if group_entity is None:
+            raise RuntimeError("Telegram did not return created group entity")
+
+        if group_kind == "supergroup":
+            from telethon.tl.functions.channels import InviteToChannelRequest
+
+            for user_identifier, user_entity in zip(invitees, user_entities):
+                try:
+                    if isinstance(group_entity, Channel):
+                        await _safe_api_call(
+                            self.client,
+                            InviteToChannelRequest(
+                                channel=group_entity, users=[user_entity]
+                            ),
+                            operation_type="join",
+                        )
+                    else:
+                        from telethon.tl.functions.messages import AddChatUserRequest
+
+                        await _safe_api_call(
+                            self.client,
+                            AddChatUserRequest(
+                                chat_id=group_entity.id,
+                                user_id=user_entity,
+                                fwd_limit=0,
+                            ),
+                            operation_type="join",
+                        )
+                    invite_results.append(
+                        {
+                            "success": True,
+                            "user": str(user_identifier),
+                            "user_id": user_entity.id,
+                            "username": user_entity.username,
+                        }
+                    )
+                except UserAlreadyParticipantError:
+                    invite_results.append(
+                        {
+                            "success": True,
+                            "already_member": True,
+                            "user": str(user_identifier),
+                            "user_id": user_entity.id,
+                            "username": user_entity.username,
+                        }
+                    )
+                except Exception as exc:
+                    invite_results.append(
+                        {
+                            "success": False,
+                            "user": str(user_identifier),
+                            "user_id": user_entity.id,
+                            "username": user_entity.username,
+                            "error": str(exc),
+                        }
+                    )
+
+        result.update(
+            {
+                "group_id": group_entity.id,
+                "group_title": getattr(group_entity, "title", clean_title),
+                "group_username": getattr(group_entity, "username", None),
+                "group_type": (
+                    "channel" if isinstance(group_entity, Channel) else "group"
+                ),
+                "invites": invite_results,
+            }
+        )
+        return result
+
+    async def set_channel_comments_join_requirement(
+        self,
+        channel_identifier: Union[str, int],
+        join_required: bool,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Включает/выключает требование join-to-send у linked discussion group канала."""
+        try:
+            linked_entity, info = await self._resolve_linked_discussion_group(
+                channel_identifier
+            )
+            result = {
+                "success": True,
+                "action": "set_channel_comments_join_requirement",
+                "dry_run": dry_run,
+                "join_required": bool(join_required),
+                **info,
+            }
+
+            if dry_run:
+                return result
+
+            from telethon.tl.functions.channels import ToggleJoinToSendRequest
+
+            await _safe_api_call(
+                self.client,
+                ToggleJoinToSendRequest(
+                    channel=linked_entity,
+                    enabled=bool(join_required),
+                ),
+                operation_type="api",
+            )
+            result["current_join_required"] = bool(join_required)
+            return result
+        except Exception as e:
+            logger.error(
+                "Error updating comments join requirement for %s: %s",
+                channel_identifier,
+                e,
+            )
+            return {
+                "success": False,
+                "action": "set_channel_comments_join_requirement",
+                "dry_run": dry_run,
+                "channel": str(channel_identifier),
+                "join_required": bool(join_required),
+                "error": str(e),
+            }
 
     async def add_member_to_group(
         self,
@@ -799,7 +1353,7 @@ class GroupManager:
             group_entity = await self._resolve_group_entity_for_admin(group_identifier)
             user_entity = await self._resolve_user_entity_for_admin(user_identifier)
 
-            group_type = 'channel' if isinstance(group_entity, Channel) else 'group'
+            group_type = "channel" if isinstance(group_entity, Channel) else "group"
             result = {
                 "success": True,
                 "action": "add_member",
@@ -815,6 +1369,7 @@ class GroupManager:
 
             if isinstance(group_entity, Channel):
                 from telethon.tl.functions.channels import InviteToChannelRequest
+
                 await _safe_api_call(
                     self.client,
                     InviteToChannelRequest(channel=group_entity, users=[user_entity]),
@@ -822,6 +1377,7 @@ class GroupManager:
                 )
             else:
                 from telethon.tl.functions.messages import AddChatUserRequest
+
                 await _safe_api_call(
                     self.client,
                     AddChatUserRequest(
@@ -843,7 +1399,9 @@ class GroupManager:
                 "user": str(user_identifier),
             }
         except Exception as e:
-            logger.error(f"Error adding user {user_identifier} to group {group_identifier}: {e}")
+            logger.error(
+                f"Error adding user {user_identifier} to group {group_identifier}: {e}"
+            )
             return {
                 "success": False,
                 "action": "add_member",
@@ -864,7 +1422,7 @@ class GroupManager:
             group_entity = await self._resolve_group_entity_for_admin(group_identifier)
             user_entity = await self._resolve_user_entity_for_admin(user_identifier)
 
-            group_type = 'channel' if isinstance(group_entity, Channel) else 'group'
+            group_type = "channel" if isinstance(group_entity, Channel) else "group"
             result = {
                 "success": True,
                 "action": "remove_member",
@@ -905,6 +1463,7 @@ class GroupManager:
                 )
             else:
                 from telethon.tl.functions.messages import DeleteChatUserRequest
+
                 await _safe_api_call(
                     self.client,
                     DeleteChatUserRequest(
@@ -926,7 +1485,9 @@ class GroupManager:
                 "user": str(user_identifier),
             }
         except Exception as e:
-            logger.error(f"Error removing user {user_identifier} from group {group_identifier}: {e}")
+            logger.error(
+                f"Error removing user {user_identifier} from group {group_identifier}: {e}"
+            )
             return {
                 "success": False,
                 "action": "remove_member",
@@ -966,7 +1527,8 @@ class GroupManager:
 
         if dry_run:
             return {
-                "success": add_preview.get("success", False) and remove_preview.get("success", False),
+                "success": add_preview.get("success", False)
+                and remove_preview.get("success", False),
                 "action": "migrate_member",
                 "dry_run": True,
                 "group": str(group_identifier),
@@ -1004,7 +1566,9 @@ class GroupManager:
             "remove_old_user": remove_result,
         }
 
-    async def send_message(self, group_identifier: Union[str, int], message_text: str) -> bool:
+    async def send_message(
+        self, group_identifier: Union[str, int], message_text: str
+    ) -> bool:
         """
         Отправляет сообщение в группу с антиспам защитой
 
@@ -1017,7 +1581,7 @@ class GroupManager:
         """
         try:
             entity = await self._resolve_target_entity(group_identifier)
-            
+
             # Отправляем сообщение через safe_call с антиспам защитой
             await _safe_api_call(
                 self.client.send_message,
@@ -1025,15 +1589,19 @@ class GroupManager:
                 message_text,
                 operation_type="group_msg",
             )
-            
+
             logger.info(f"Сообщение успешно отправлено в группу {group_identifier}")
             return True
-            
+
         except Exception as e:
-            logger.error(f"Ошибка при отправке сообщения в группу {group_identifier}: {e}")
+            logger.error(
+                f"Ошибка при отправке сообщения в группу {group_identifier}: {e}"
+            )
             return False
 
-    async def send_file(self, group_identifier: Union[str, int], file_path: str, caption: str = "") -> bool:
+    async def send_file(
+        self, group_identifier: Union[str, int], file_path: str, caption: str = ""
+    ) -> bool:
         """Отправляет файл в группу/чат с антиспам защитой."""
         try:
             entity = await self._resolve_target_entity(group_identifier)
@@ -1050,6 +1618,287 @@ class GroupManager:
             logger.error(f"Ошибка при отправке файла в группу {group_identifier}: {e}")
             return False
 
+    async def delete_messages(
+        self,
+        group_identifier: Union[str, int],
+        message_ids: Union[int, List[int], tuple, set],
+        revoke: bool = True,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Удаляет конкретные сообщения в группе/чате."""
+        try:
+            entity = await self._resolve_target_entity(group_identifier)
+            normalized_ids = self._normalize_message_ids(message_ids)
+            result = {
+                "success": True,
+                "action": "delete_messages",
+                "dry_run": dry_run,
+                "target": str(group_identifier),
+                "message_ids": normalized_ids,
+                "message_count": len(normalized_ids),
+                "revoke": bool(revoke),
+            }
+
+            if dry_run:
+                return result
+
+            await _safe_api_call(
+                self.client.delete_messages,
+                entity,
+                normalized_ids,
+                revoke=bool(revoke),
+                operation_type="api",
+            )
+            return result
+        except Exception as e:
+            logger.error(f"Ошибка при удалении сообщений в {group_identifier}: {e}")
+            return {
+                "success": False,
+                "action": "delete_messages",
+                "dry_run": dry_run,
+                "target": str(group_identifier),
+                "error": str(e),
+            }
+
+    async def clear_history(
+        self,
+        group_identifier: Union[str, int],
+        max_id: int = 0,
+        revoke: bool = True,
+        just_clear: bool = False,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Очищает историю диалога/чата через DeleteHistoryRequest."""
+        try:
+            entity = await self._resolve_target_entity(group_identifier)
+            normalized_max_id = int(max_id or 0)
+            if normalized_max_id < 0:
+                raise ValueError("max_id must be >= 0")
+
+            result = {
+                "success": True,
+                "action": "clear_history",
+                "dry_run": dry_run,
+                "target": str(group_identifier),
+                "max_id": normalized_max_id,
+                "revoke": bool(revoke),
+                "just_clear": bool(just_clear),
+            }
+
+            if dry_run:
+                return result
+
+            from telethon.tl.functions.messages import DeleteHistoryRequest
+
+            await _safe_api_call(
+                self.client,
+                DeleteHistoryRequest(
+                    peer=entity,
+                    max_id=normalized_max_id,
+                    revoke=bool(revoke),
+                    just_clear=bool(just_clear),
+                    min_date=None,
+                    max_date=None,
+                ),
+                operation_type="api",
+            )
+            return result
+        except Exception as e:
+            logger.error(f"Ошибка при очистке истории {group_identifier}: {e}")
+            return {
+                "success": False,
+                "action": "clear_history",
+                "dry_run": dry_run,
+                "target": str(group_identifier),
+                "error": str(e),
+            }
+
+    async def leave_dialog(
+        self,
+        group_identifier: Union[str, int],
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Leave a channel/supergroup/basic group. Direct user dialogs are not leaveable."""
+        try:
+            entity = await self._resolve_target_entity(group_identifier)
+            if isinstance(entity, User):
+                return {
+                    "success": False,
+                    "action": "leave_dialog",
+                    "dry_run": dry_run,
+                    "target": str(group_identifier),
+                    "error": (
+                        "Direct user dialogs cannot be left; delete messages "
+                        "or clear history instead."
+                    ),
+                }
+
+            if isinstance(entity, Channel):
+                dialog_type = "channel" if entity.broadcast else "supergroup"
+            elif isinstance(entity, Chat):
+                dialog_type = "group"
+            else:
+                dialog_type = type(entity).__name__
+
+            result = {
+                "success": True,
+                "action": "leave_dialog",
+                "dry_run": dry_run,
+                "target": str(group_identifier),
+                "dialog_id": getattr(entity, "id", None),
+                "dialog_type": dialog_type,
+                "title": getattr(entity, "title", None),
+                "username": getattr(entity, "username", None),
+            }
+
+            if dry_run:
+                return result
+
+            if isinstance(entity, Channel):
+                from telethon.tl.functions.channels import LeaveChannelRequest
+
+                await _safe_api_call(
+                    self.client,
+                    LeaveChannelRequest(channel=entity),
+                    operation_type="join",
+                )
+                return result
+
+            if isinstance(entity, Chat):
+                from telethon.tl.functions.messages import DeleteChatUserRequest
+
+                me = await _safe_api_call(self.client.get_me, operation_type="api")
+                await _safe_api_call(
+                    self.client,
+                    DeleteChatUserRequest(
+                        chat_id=entity.id,
+                        user_id=me,
+                        revoke_history=False,
+                    ),
+                    operation_type="join",
+                )
+                return result
+
+            return {
+                **result,
+                "success": False,
+                "error": f"Unsupported dialog entity type: {type(entity).__name__}",
+            }
+        except Exception as e:
+            logger.error(f"Ошибка при выходе из диалога {group_identifier}: {e}")
+            return {
+                "success": False,
+                "action": "leave_dialog",
+                "dry_run": dry_run,
+                "target": str(group_identifier),
+                "error": str(e),
+            }
+
+    async def edit_message(
+        self,
+        group_identifier: Union[str, int],
+        message_id: int,
+        new_text: str,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Редактирует сообщение в диалоге/чате."""
+        try:
+            entity = await self._resolve_target_entity(group_identifier)
+            normalized_message_id = int(message_id)
+            if normalized_message_id <= 0:
+                raise ValueError("message_id must be > 0")
+
+            clean_text = str(new_text or "").strip()
+            if not clean_text:
+                raise ValueError("new_text is empty")
+
+            result = {
+                "success": True,
+                "action": "edit_message",
+                "dry_run": dry_run,
+                "target": str(group_identifier),
+                "message_id": normalized_message_id,
+                "new_text_len": len(clean_text),
+            }
+
+            if dry_run:
+                return result
+
+            await _safe_api_call(
+                self.client.edit_message,
+                entity,
+                normalized_message_id,
+                clean_text,
+                operation_type="group_msg",
+            )
+            return result
+        except Exception as e:
+            logger.error(
+                f"Ошибка при редактировании сообщения {message_id} в {group_identifier}: {e}"
+            )
+            return {
+                "success": False,
+                "action": "edit_message",
+                "dry_run": dry_run,
+                "target": str(group_identifier),
+                "error": str(e),
+            }
+
+    async def forward_messages(
+        self,
+        from_group_identifier: Union[str, int],
+        to_group_identifier: Union[str, int],
+        message_ids: Union[int, List[int], tuple, set],
+        drop_author: bool = False,
+        drop_media_captions: bool = False,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Пересылает сообщения из одного диалога в другой."""
+        try:
+            source_entity = await self._resolve_target_entity(from_group_identifier)
+            target_entity = await self._resolve_target_entity(to_group_identifier)
+            normalized_ids = self._normalize_message_ids(message_ids)
+            result = {
+                "success": True,
+                "action": "forward_messages",
+                "dry_run": dry_run,
+                "from_target": str(from_group_identifier),
+                "to_target": str(to_group_identifier),
+                "message_ids": normalized_ids,
+                "message_count": len(normalized_ids),
+                "drop_author": bool(drop_author),
+                "drop_media_captions": bool(drop_media_captions),
+            }
+
+            if dry_run:
+                return result
+
+            await _safe_api_call(
+                self.client.forward_messages,
+                target_entity,
+                normalized_ids,
+                from_peer=source_entity,
+                drop_author=bool(drop_author),
+                drop_media_captions=bool(drop_media_captions),
+                operation_type="group_msg",
+            )
+            return result
+        except Exception as e:
+            logger.error(
+                "Ошибка при пересылке сообщений %s -> %s: %s",
+                from_group_identifier,
+                to_group_identifier,
+                e,
+            )
+            return {
+                "success": False,
+                "action": "forward_messages",
+                "dry_run": dry_run,
+                "from_target": str(from_group_identifier),
+                "to_target": str(to_group_identifier),
+                "error": str(e),
+            }
+
     async def _resolve_target_entity(self, group_identifier: Union[str, int]):
         """Разрешает target в Telethon entity для write-операций."""
         entity = None
@@ -1057,17 +1906,25 @@ class GroupManager:
         if isinstance(group_identifier, int):
             return await _safe_api_call(self.client.get_entity, group_identifier)
 
-        if isinstance(group_identifier, str) and (group_identifier.startswith('-') and group_identifier[1:].isdigit()):
+        if isinstance(group_identifier, str) and group_identifier.isdigit():
             return await _safe_api_call(self.client.get_entity, int(group_identifier))
 
-        if isinstance(group_identifier, str) and ' ' in group_identifier:
+        if isinstance(group_identifier, str) and (
+            group_identifier.startswith("-") and group_identifier[1:].isdigit()
+        ):
+            return await _safe_api_call(self.client.get_entity, int(group_identifier))
+
+        if isinstance(group_identifier, str) and " " in group_identifier:
             # Название с пробелами — ищем только через диалоги
             logger.info(f"Searching for group by title: '{group_identifier}'")
 
             async def search_dialogs():
                 dialogs = []
                 async for dialog in self.client.iter_dialogs(limit=500):
-                    if dialog.title and group_identifier.lower() in dialog.title.lower():
+                    if (
+                        dialog.title
+                        and group_identifier.lower() in dialog.title.lower()
+                    ):
                         dialogs.append(dialog)
                 return dialogs
 
@@ -1091,8 +1948,8 @@ class GroupManager:
         # This keeps write actions usable for 1:1 assignment delivery via ActionMCP.
         username_target = (
             str(group_identifier)
-            if str(group_identifier).startswith('@')
-            else '@' + str(group_identifier)
+            if str(group_identifier).startswith("@")
+            else "@" + str(group_identifier)
         )
         try:
             entity = await _safe_api_call(self.client.get_entity, username_target)
@@ -1103,5 +1960,5 @@ class GroupManager:
 
         group_info = await self.get_group_info(str(group_identifier))
         if group_info:
-            return await _safe_api_call(self.client.get_entity, group_info['id'])
+            return await _safe_api_call(self.client.get_entity, group_info["id"])
         raise ValueError(f"Группа '{group_identifier}' не найдена")


### PR DESCRIPTION
Published directly to `main` at `6d2db0a` so the repository can be downloaded from the default branch.

Validation before publishing:

- `PYTHONPATH=tganalytics:. venv/bin/python3 -m pytest tests/ -q` -> 114 passed
- `venv/bin/python3 scripts/check_anti_spam_compliance.py` -> passed
- staged secret/local-artifact scans in the publish branch -> no real keys, sessions, data downloads, or chat-analysis files staged

This draft PR is closed because the same commits were fast-forwarded and pushed to `main`.